### PR TITLE
fix: offset world boundary plane to account for shape thickness

### DIFF
--- a/src/objects/box3d_shaped_object_impl_3d.cpp
+++ b/src/objects/box3d_shaped_object_impl_3d.cpp
@@ -132,7 +132,7 @@ b3ShapeId create_box3d_shape(
 				const real_t angle = Math::acos(CLAMP(up.dot(normal), -1.0, 1.0));
 				basis = Basis(axis, angle);
 			}
-			const Vector3 origin = normal * (real_t)plane.d;
+			const Vector3 origin = normal * (real_t)(plane.d - Box3DWorldBoundaryShapeImpl3D::PLATE_HALF_THICKNESS);
 			const Transform3D plate_transform(basis, origin);
 			const Transform3D combined = local * plate_transform;
 			const b3Transform box_transform = godot_to_b3_transform(combined);


### PR DESCRIPTION
Hello, 

I've tested the WorldBoundaryShape3D and noticed the collisions were offset by 5.0 units above the origin of the plane.

This PR is a small fix to account for the shape's thickness so the plane displayed in the editor matches the actual collision.

Before:
<img width="964" height="551" alt="image" src="https://github.com/user-attachments/assets/f33a8d7a-2bae-46ce-8b4d-2830d81d4d39" />

After:
<img width="772" height="453" alt="image" src="https://github.com/user-attachments/assets/7c73c815-a522-4e0a-a83b-a04ab978b42f" />

Cheers!