### PR TITLE
Fix server simulating in editor

### DIFF
--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -1227,13 +1227,16 @@ void Box3DPhysicsServer3D::_free_rid(const RID& p_rid) {
 }
 
 void Box3DPhysicsServer3D::_set_active(bool p_active) {
-	// Individual space activation is handled via _space_set_active; nothing global to do.
+	active = p_active;
 }
 
 void Box3DPhysicsServer3D::_init() {
 }
 
 void Box3DPhysicsServer3D::_step(double p_step) {
+	if (!active) {
+		return;
+	}
 	for (Box3DSpace3D* space : active_spaces) {
 		space->step((float)p_step);
 	}
@@ -1243,6 +1246,9 @@ void Box3DPhysicsServer3D::_sync() {
 }
 
 void Box3DPhysicsServer3D::_flush_queries() {
+	if (!active) {
+		return;
+	}
 	for (Box3DSpace3D* space : active_spaces) {
 		space->flush_queries();
 	}

--- a/src/servers/box3d_physics_server_3d.hpp
+++ b/src/servers/box3d_physics_server_3d.hpp
@@ -272,4 +272,5 @@ private:
 	RID_PtrOwner<Box3DJointImpl3D> joint_owner;
 
 	HashSet<Box3DSpace3D*> active_spaces;
+	bool active = true;
 };


### PR DESCRIPTION
I noticed sometimes after running a project, the physics simulation would continue to run in the editor afterwards and could not be stopped.

The problem is easily reproducible.  Create a new project, add a RigidBody3D node, and change the velocity to anything nonzero in Inspector -> RigidBody3D -> Linear -> Velocity and it will immediately fly away in the editor without even having to run the project.

I copied the solution godot-jolt uses in its server to `Box3DPhysicsServer3D::_set_active` and the problem is fixed.