### PR TITLE
Match Godot collision layer and mask semantics

### DIFF
--- a/src/misc/type_conversions.hpp
+++ b/src/misc/type_conversions.hpp
@@ -62,6 +62,28 @@ _FORCE_INLINE_ b3AABB godot_to_b3(const AABB& p_aabb) {
 	return aabb;
 }
 
+// Box3D requires both objects to accept each other, while Godot creates a collision
+// pair when either object's mask accepts the other object's layer. Packing Godot's
+// 32-bit layer and mask into opposite halves of Box3D's 64-bit fields makes both of
+// Box3D's tests evaluate to the same Godot OR expression:
+//
+//   (mask_a & layer_b) != 0 || (layer_a & mask_b) != 0
+_FORCE_INLINE_ b3Filter godot_to_b3_filter(uint32_t p_layer, uint32_t p_mask) {
+	b3Filter filter = b3DefaultFilter();
+	filter.categoryBits = (uint64_t)p_layer | ((uint64_t)p_mask << 32);
+	filter.maskBits = (uint64_t)p_mask | ((uint64_t)p_layer << 32);
+	return filter;
+}
+
+// Godot direct-space queries only compare their collision mask with a target's layer.
+// Mirror that comparison into both halves expected by Box3D's symmetric query filter.
+_FORCE_INLINE_ b3QueryFilter godot_to_b3_query_filter(uint32_t p_collision_mask) {
+	b3QueryFilter filter = b3DefaultQueryFilter();
+	filter.categoryBits = (uint64_t)p_collision_mask << 32;
+	filter.maskBits = (uint64_t)p_collision_mask;
+	return filter;
+}
+
 _FORCE_INLINE_ Plane b3_to_godot(const b3Plane& p_plane) {
 	return Plane(b3_to_godot(p_plane.normal), p_plane.offset);
 }

--- a/src/objects/box3d_shaped_object_impl_3d.cpp
+++ b/src/objects/box3d_shaped_object_impl_3d.cpp
@@ -36,8 +36,7 @@ b3ShapeId create_box3d_shape(
 
 	b3ShapeDef def = b3DefaultShapeDef();
 	def.userData = p_user_data;
-	def.filter.categoryBits = (uint64_t)p_layer;
-	def.filter.maskBits = (uint64_t)p_mask;
+	def.filter = godot_to_b3_filter(p_layer, p_mask);
 	def.isSensor = p_is_sensor;
 	// Box3D requires *both* sides of a sensor overlap to opt into sensor events (see
 	// b3ShapeDef::enableSensorEvents doc comment: "This applies to sensors and

--- a/src/spaces/box3d_physics_direct_space_state_3d.cpp
+++ b/src/spaces/box3d_physics_direct_space_state_3d.cpp
@@ -342,7 +342,7 @@ bool Box3DPhysicsDirectSpaceState3D::test_body_motion(
 	}
 
 	Box3DQueryFilter3D filter;
-	filter.filter.maskBits = (uint64_t)p_body.get_collision_mask();
+	filter.set_collision_mask(p_body.get_collision_mask());
 	filter.exclude.insert(p_body.get_rid());
 
 	const Box3DShapeProxy3D shape_proxy(first_shape, p_transform * p_body.get_shape_transform(0));

--- a/src/spaces/box3d_query_filter_3d.hpp
+++ b/src/spaces/box3d_query_filter_3d.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../misc/type_conversions.hpp"
+
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/variant/rid.hpp>
 
@@ -7,12 +9,12 @@
 
 using namespace godot;
 
-// Builds a b3QueryFilter (direct 32-bit zero-extended layer/mask pass-through, per the
-// plan) plus a side-channel RID exclude-set, since Box3D's own filter has no native
-// per-query RID-exclude list. Callers check should_exclude() from inside their
-// b3*ResultFcn/b3CastResultFcn callback alongside whatever the callback itself needs.
+// Builds a b3QueryFilter matching Godot's mask-vs-layer query semantics, plus a
+// side-channel RID exclude-set since Box3D has no native per-query RID-exclude list.
+// Callers check should_exclude() from inside their b3*ResultFcn/b3CastResultFcn callback
+// alongside whatever the callback itself needs.
 struct Box3DQueryFilter3D {
-	b3QueryFilter filter = b3DefaultQueryFilter();
+	b3QueryFilter filter = godot_to_b3_query_filter(UINT32_MAX);
 	HashSet<RID> exclude;
 	bool collide_with_bodies = true;
 	bool collide_with_areas = false;
@@ -21,9 +23,10 @@ struct Box3DQueryFilter3D {
 
 	Box3DQueryFilter3D(uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) :
 			collide_with_bodies(p_collide_with_bodies), collide_with_areas(p_collide_with_areas) {
-		filter = b3DefaultQueryFilter();
-		filter.maskBits = (uint64_t)p_collision_mask;
+		set_collision_mask(p_collision_mask);
 	}
+
+	void set_collision_mask(uint32_t p_collision_mask) { filter = godot_to_b3_query_filter(p_collision_mask); }
 
 	bool should_exclude(const RID& p_rid) const { return exclude.has(p_rid); }
 };

--- a/test_project/collision_filter_test.gd
+++ b/test_project/collision_filter_test.gd
@@ -1,0 +1,83 @@
+extends SceneTree
+
+var failures: int = 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	_check(ProjectSettings.get_setting("physics/3d/physics_engine", "") == "Box3D Physics (Extension)", "test project requests the Box3D backend")
+	_check(ClassDB.class_exists(&"Box3DPhysicsServer3D"), "Box3D extension is loaded")
+	if failures > 0:
+		quit(1)
+		return
+
+	var accepts_floor := _make_floor(Vector3(-4, -0.5, 0), 1, 0)
+	var floor_accepts := _make_floor(Vector3(0, -0.5, 0), 1, 2)
+	_make_floor(Vector3(4, -0.5, 0), 1, 0)
+
+	var body_accepts := _make_body(Vector3(-4, 3, 0), 2, 1)
+	var accepted_by_floor := _make_body(Vector3(0, 3, 0), 2, 0)
+	var no_match := _make_body(Vector3(4, 3, 0), 2, 0)
+
+	for frame in 240:
+		await physics_frame
+
+	_check(body_accepts.global_position.y > -1.0, "body mask accepting the floor creates a collision pair")
+	_check(accepted_by_floor.global_position.y > -1.0, "floor mask accepting the body creates a collision pair")
+	_check(no_match.global_position.y < -5.0, "objects with no layer/mask match do not collide")
+
+	var query_target := _make_floor(Vector3(10, 0, 0), 4, 0)
+	await physics_frame
+	var query := PhysicsRayQueryParameters3D.create(Vector3(10, 3, 0), Vector3(10, -3, 0))
+	query.collision_mask = 4
+	var hit := root.world_3d.direct_space_state.intersect_ray(query)
+	_check(not hit.is_empty(), "direct queries match a target layer regardless of the target mask")
+
+	accepts_floor.queue_free()
+	floor_accepts.queue_free()
+	query_target.queue_free()
+	if failures == 0:
+		print("RESULT: PASS - collision filters match Godot semantics")
+	else:
+		print("RESULT: FAIL - ", failures, " collision filter assertion(s) failed")
+	quit(1 if failures > 0 else 0)
+
+
+func _make_floor(position: Vector3, layer: int, mask: int) -> StaticBody3D:
+	var floor := StaticBody3D.new()
+	floor.position = position
+	floor.collision_layer = layer
+	floor.collision_mask = mask
+	var collision_shape := CollisionShape3D.new()
+	var shape := BoxShape3D.new()
+	shape.size = Vector3(3, 1, 3)
+	collision_shape.shape = shape
+	floor.add_child(collision_shape)
+	root.add_child(floor)
+	return floor
+
+
+func _make_body(position: Vector3, layer: int, mask: int) -> RigidBody3D:
+	var body := RigidBody3D.new()
+	body.position = position
+	body.collision_layer = layer
+	body.collision_mask = mask
+	body.can_sleep = false
+	var collision_shape := CollisionShape3D.new()
+	var shape := SphereShape3D.new()
+	shape.radius = 0.5
+	collision_shape.shape = shape
+	body.add_child(collision_shape)
+	root.add_child(body)
+	return body
+
+
+func _check(condition: bool, message: String) -> void:
+	if condition:
+		print("PASS: ", message)
+	else:
+		failures += 1
+		push_error("FAIL: " + message)

--- a/test_project/collision_filter_test.gd.uid
+++ b/test_project/collision_filter_test.gd.uid
@@ -1,0 +1,1 @@
+uid://c1mufd0ujrdal


### PR DESCRIPTION
## Summary

- Match Godot's one-directional collision layer/mask pairing rule while retaining all 32 Godot layers.
- Adapt direct-space and body-motion query filters so a query depends only on its mask and the target layer.
- Add a headless regression covering both one-way collision directions, a non-match control, and target-mask-independent ray queries.

## Root cause

Box3D requires both objects' filters to accept each other, while Godot creates a pair when either object's mask accepts the other's layer. The change packs each 32-bit Godot layer and mask into opposite halves of Box3D's 64-bit category/mask fields. Both of Box3D's symmetric checks then evaluate to Godot's OR expression.

This addresses the pre-existing mismatch noted during review of #4 and is independently mergeable against current `main`.

## User impact

Asymmetric Godot collision configurations now behave the same under Box3D as under GodotPhysics3D. Direct queries also hit matching target layers even when the target's own collision mask is empty.

## Validation

- macOS CMake build against the project-pinned Godot 4.3 bindings and vendored Box3D v0.1.0.
- `collision_filter_test.gd` passes with Godot 4.6.3 and Godot 4.7.1.
- Existing fall, area-monitoring, and joint smoke tests pass with Godot 4.7.1.
