### PR TITLE
Resolve space RIDs to their default area

### DIFF
--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -298,18 +298,30 @@ void Box3DPhysicsServer3D::_area_clear_shapes(const RID& p_area) {
 
 void Box3DPhysicsServer3D::_area_attach_object_instance_id(const RID& p_area, uint64_t p_id) {
 	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
+	if (area == nullptr) {
+		Box3DSpace3D* space = space_owner.get_or_null(p_area);
+		area = space != nullptr ? space->get_default_area() : nullptr;
+	}
 	ERR_FAIL_NULL(area);
 	area->set_instance_id(p_id);
 }
 
 uint64_t Box3DPhysicsServer3D::_area_get_object_instance_id(const RID& p_area) const {
 	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
+	if (area == nullptr) {
+		Box3DSpace3D* space = space_owner.get_or_null(p_area);
+		area = space != nullptr ? space->get_default_area() : nullptr;
+	}
 	ERR_FAIL_NULL_V(area, 0);
 	return area->get_instance_id();
 }
 
 void Box3DPhysicsServer3D::_area_set_param(const RID& p_area, PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
 	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
+	if (area == nullptr) {
+		Box3DSpace3D* space = space_owner.get_or_null(p_area);
+		area = space != nullptr ? space->get_default_area() : nullptr;
+	}
 	ERR_FAIL_NULL(area);
 	area->set_param(p_param, p_value);
 }
@@ -322,6 +334,10 @@ void Box3DPhysicsServer3D::_area_set_transform(const RID& p_area, const Transfor
 
 Variant Box3DPhysicsServer3D::_area_get_param(const RID& p_area, PhysicsServer3D::AreaParameter p_param) const {
 	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
+	if (area == nullptr) {
+		Box3DSpace3D* space = space_owner.get_or_null(p_area);
+		area = space != nullptr ? space->get_default_area() : nullptr;
+	}
 	ERR_FAIL_NULL_V(area, Variant());
 	return area->get_param(p_param);
 }

--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -297,31 +297,37 @@ void Box3DPhysicsServer3D::_area_clear_shapes(const RID& p_area) {
 }
 
 void Box3DPhysicsServer3D::_area_attach_object_instance_id(const RID& p_area, uint64_t p_id) {
-	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
-	if (area == nullptr) {
-		Box3DSpace3D* space = space_owner.get_or_null(p_area);
-		area = space != nullptr ? space->get_default_area() : nullptr;
+	RID area_rid = p_area;
+	if (space_owner.owns(area_rid)) {
+		const Box3DSpace3D* space = space_owner.get_or_null(area_rid);
+		area_rid = space->get_default_area()->get_rid();
 	}
+
+	Box3DAreaImpl3D* area = area_owner.get_or_null(area_rid);
 	ERR_FAIL_NULL(area);
 	area->set_instance_id(p_id);
 }
 
 uint64_t Box3DPhysicsServer3D::_area_get_object_instance_id(const RID& p_area) const {
-	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
-	if (area == nullptr) {
-		Box3DSpace3D* space = space_owner.get_or_null(p_area);
-		area = space != nullptr ? space->get_default_area() : nullptr;
+	RID area_rid = p_area;
+	if (space_owner.owns(area_rid)) {
+		const Box3DSpace3D* space = space_owner.get_or_null(area_rid);
+		area_rid = space->get_default_area()->get_rid();
 	}
+
+	Box3DAreaImpl3D* area = area_owner.get_or_null(area_rid);
 	ERR_FAIL_NULL_V(area, 0);
 	return area->get_instance_id();
 }
 
 void Box3DPhysicsServer3D::_area_set_param(const RID& p_area, PhysicsServer3D::AreaParameter p_param, const Variant& p_value) {
-	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
-	if (area == nullptr) {
-		Box3DSpace3D* space = space_owner.get_or_null(p_area);
-		area = space != nullptr ? space->get_default_area() : nullptr;
+	RID area_rid = p_area;
+	if (space_owner.owns(area_rid)) {
+		const Box3DSpace3D* space = space_owner.get_or_null(area_rid);
+		area_rid = space->get_default_area()->get_rid();
 	}
+
+	Box3DAreaImpl3D* area = area_owner.get_or_null(area_rid);
 	ERR_FAIL_NULL(area);
 	area->set_param(p_param, p_value);
 }
@@ -333,11 +339,13 @@ void Box3DPhysicsServer3D::_area_set_transform(const RID& p_area, const Transfor
 }
 
 Variant Box3DPhysicsServer3D::_area_get_param(const RID& p_area, PhysicsServer3D::AreaParameter p_param) const {
-	Box3DAreaImpl3D* area = area_owner.get_or_null(p_area);
-	if (area == nullptr) {
-		Box3DSpace3D* space = space_owner.get_or_null(p_area);
-		area = space != nullptr ? space->get_default_area() : nullptr;
+	RID area_rid = p_area;
+	if (space_owner.owns(area_rid)) {
+		const Box3DSpace3D* space = space_owner.get_or_null(area_rid);
+		area_rid = space->get_default_area()->get_rid();
 	}
+
+	Box3DAreaImpl3D* area = area_owner.get_or_null(area_rid);
 	ERR_FAIL_NULL_V(area, Variant());
 	return area->get_param(p_param);
 }

--- a/test_project/default_area_test.gd
+++ b/test_project/default_area_test.gd
@@ -1,0 +1,39 @@
+extends SceneTree
+
+var failures: int = 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var space: RID = root.world_3d.space
+	_check(space.is_valid(), "world has a valid physics space")
+	if not space.is_valid():
+		quit(1)
+		return
+
+	var expected_gravity: float = 3.25
+	PhysicsServer3D.area_set_param(space, PhysicsServer3D.AREA_PARAM_GRAVITY, expected_gravity)
+	var gravity: float = float(PhysicsServer3D.area_get_param(space, PhysicsServer3D.AREA_PARAM_GRAVITY))
+	_check(is_equal_approx(gravity, expected_gravity), "space RID reads and writes default-area parameters")
+
+	var expected_instance_id: int = get_instance_id()
+	PhysicsServer3D.area_attach_object_instance_id(space, expected_instance_id)
+	var instance_id: int = PhysicsServer3D.area_get_object_instance_id(space)
+	_check(instance_id == expected_instance_id, "space RID reads and writes the default-area instance ID")
+
+	if failures == 0:
+		print("RESULT: PASS - space RID resolves to the default area")
+	else:
+		print("RESULT: FAIL - ", failures, " default-area assertion(s) failed")
+	quit(1 if failures > 0 else 0)
+
+
+func _check(condition: bool, message: String) -> void:
+	if condition:
+		print("PASS: ", message)
+	else:
+		failures += 1
+		push_error("FAIL: " + message)

--- a/test_project/default_area_test.gd.uid
+++ b/test_project/default_area_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cg6fg3j61rd2c


### PR DESCRIPTION
## Summary

- resolve a space RID to its default area for area parameters and instance IDs
- add a focused regression test for both API paths

## Why

Godot initializes each `World3D` by passing its space RID to `area_set_param()`. The built-in Godot Physics and Jolt backends resolve that RID to the space's default area, but this extension currently rejects it as an unknown area. As a result, normal scene startup logs null-area errors and the default gravity/damping values are not applied through the expected API.

This is a focused replacement extracted from #4.

## Validation

- extension builds from current upstream `main`
- all existing headless tests pass without the null-area errors
- `godot --headless --path test_project --script res://default_area_test.gd`
- `git diff --check`
- no inferred (`:=`) declarations in the new test
