### PR TITLE
Add CylinderShape3D support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The structure of this extension is based on [godot-jolt](https://github.com/godo
 ## What works
 
 - Rigid, static, and kinematic bodies
-- Shapes: box, sphere, capsule, convex polygon, concave polygon (trimesh), heightmap, and world boundary
+- Shapes: box, sphere, capsule, cylinder, convex polygon, concave polygon (trimesh), heightmap, and world boundary
 - Areas, including overlap events and gravity/damping overrides
 - Direct space state queries: ray casts, point and shape intersection, shape casts (`cast_motion`), `collide_shape`, and `rest_info`
 - `body_test_motion`, so `CharacterBody3D` and `move_and_slide()` work
@@ -18,7 +18,7 @@ The structure of this extension is based on [godot-jolt](https://github.com/godo
 
 ## What's left to do
 
-- Cylinder and separation ray shapes (not supported by Box3D)
+- Separation ray shapes
 - ConeTwist and Generic6DOF joints
 - `SoftBody3D`
 - Per-pair collision exceptions (use collision layers/masks for now)

--- a/src/objects/box3d_shaped_object_impl_3d.cpp
+++ b/src/objects/box3d_shaped_object_impl_3d.cpp
@@ -5,6 +5,7 @@
 #include "../shapes/box3d_capsule_shape_impl_3d.hpp"
 #include "../shapes/box3d_concave_polygon_shape_impl_3d.hpp"
 #include "../shapes/box3d_convex_polygon_shape_impl_3d.hpp"
+#include "../shapes/box3d_cylinder_shape_impl_3d.hpp"
 #include "../shapes/box3d_heightmap_shape_impl_3d.hpp"
 #include "../shapes/box3d_shape_impl_3d.hpp"
 #include "../shapes/box3d_sphere_shape_impl_3d.hpp"
@@ -81,6 +82,21 @@ b3ShapeId create_box3d_shape(
 			const b3Transform box_transform = godot_to_b3_transform(local);
 			b3BoxHull box_hull = b3MakeTransformedBoxHull((float)half.x, (float)half.y, (float)half.z, box_transform);
 			return b3CreateHullShape(p_body_id, &def, &box_hull.base);
+		}
+
+		case PhysicsServer3D::SHAPE_CYLINDER: {
+			auto* cylinder_shape = static_cast<Box3DCylinderShapeImpl3D*>(shape);
+			const float height = (float)cylinder_shape->get_height();
+			b3HullData* cylinder = b3CreateCylinder(
+					height,
+					(float)cylinder_shape->get_radius(),
+					-0.5f * height,
+					Box3DCylinderShapeImpl3D::HULL_SIDES);
+			ERR_FAIL_NULL_V(cylinder, b3_nullShapeId);
+			const b3Transform cylinder_transform = godot_to_b3_transform(local);
+			const b3ShapeId shape_id = b3CreateTransformedHullShape(p_body_id, &def, cylinder, cylinder_transform, b3Vec3{1.0f, 1.0f, 1.0f});
+			b3DestroyHull(cylinder);
+			return shape_id;
 		}
 
 		case PhysicsServer3D::SHAPE_CONVEX_POLYGON: {

--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -13,6 +13,7 @@
 #include "../shapes/box3d_capsule_shape_impl_3d.hpp"
 #include "../shapes/box3d_concave_polygon_shape_impl_3d.hpp"
 #include "../shapes/box3d_convex_polygon_shape_impl_3d.hpp"
+#include "../shapes/box3d_cylinder_shape_impl_3d.hpp"
 #include "../shapes/box3d_heightmap_shape_impl_3d.hpp"
 #include "../shapes/box3d_shape_impl_3d.hpp"
 #include "../shapes/box3d_sphere_shape_impl_3d.hpp"
@@ -79,7 +80,10 @@ RID Box3DPhysicsServer3D::_capsule_shape_create() {
 }
 
 RID Box3DPhysicsServer3D::_cylinder_shape_create() {
-	ERR_FAIL_V_MSG(RID(), "Box3D: CylinderShape3D is not supported in this version of the Box3D extension.");
+	auto* shape = memnew(Box3DCylinderShapeImpl3D);
+	const RID rid = shape_owner.make_rid(shape);
+	shape->set_rid(rid);
+	return rid;
 }
 
 RID Box3DPhysicsServer3D::_convex_polygon_shape_create() {

--- a/src/shapes/box3d_cylinder_shape_impl_3d.cpp
+++ b/src/shapes/box3d_cylinder_shape_impl_3d.cpp
@@ -1,0 +1,22 @@
+#include "box3d_cylinder_shape_impl_3d.hpp"
+
+Variant Box3DCylinderShapeImpl3D::get_data() const {
+	Dictionary data;
+	data["radius"] = radius;
+	data["height"] = height;
+	return data;
+}
+
+void Box3DCylinderShapeImpl3D::set_data(const Variant& p_data) {
+	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);
+	const Dictionary data = p_data;
+	ERR_FAIL_COND(!data.has("radius"));
+	ERR_FAIL_COND(!data.has("height"));
+	radius = data["radius"];
+	height = data["height"];
+}
+
+AABB Box3DCylinderShapeImpl3D::get_aabb() const {
+	const Vector3 half(radius, height * 0.5, radius);
+	return AABB(-half, half * 2.0);
+}

--- a/src/shapes/box3d_cylinder_shape_impl_3d.hpp
+++ b/src/shapes/box3d_cylinder_shape_impl_3d.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "box3d_shape_impl_3d.hpp"
+
+class Box3DCylinderShapeImpl3D final : public Box3DShapeImpl3D {
+public:
+	static constexpr int HULL_SIDES = 24;
+
+	ShapeType get_type() const override { return PhysicsServer3D::SHAPE_CYLINDER; }
+
+	Variant get_data() const override;
+
+	void set_data(const Variant& p_data) override;
+
+	AABB get_aabb() const override;
+
+	real_t get_radius() const { return radius; }
+
+	real_t get_height() const { return height; }
+
+private:
+	real_t radius = 0.5;
+	real_t height = 2.0;
+};

--- a/test_project/cylinder_test.gd
+++ b/test_project/cylinder_test.gd
@@ -1,0 +1,41 @@
+extends SceneTree
+
+var failures: int = 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var target: StaticBody3D = StaticBody3D.new()
+	var collision: CollisionShape3D = CollisionShape3D.new()
+	var cylinder: CylinderShape3D = CylinderShape3D.new()
+	cylinder.radius = 0.75
+	cylinder.height = 2.0
+	collision.shape = cylinder
+	target.add_child(collision)
+	root.add_child(target)
+
+	await physics_frame
+	await physics_frame
+
+	var query: PhysicsRayQueryParameters3D = PhysicsRayQueryParameters3D.create(Vector3(0, 3, 0), Vector3(0, -3, 0))
+	var hit: Dictionary = root.world_3d.direct_space_state.intersect_ray(query)
+	_check(not hit.is_empty(), "ray query hits the cylinder")
+	var position: Vector3 = hit.get("position", Vector3())
+	_check(absf(position.y - 1.0) <= 0.05, "cylinder hull is centered on its Godot transform")
+
+	if failures == 0:
+		print("RESULT: PASS - cylinder shape is queryable and centered")
+	else:
+		print("RESULT: FAIL - ", failures, " cylinder assertion(s) failed")
+	quit(1 if failures > 0 else 0)
+
+
+func _check(condition: bool, message: String) -> void:
+	if condition:
+		print("PASS: ", message)
+	else:
+		failures += 1
+		push_error("FAIL: " + message)

--- a/test_project/cylinder_test.gd.uid
+++ b/test_project/cylinder_test.gd.uid
@@ -1,0 +1,1 @@
+uid://b7h1j28m2tq3a


### PR DESCRIPTION
## Summary

- implement `CylinderShape3D` with Box3D's convex cylinder hull helper
- center the generated hull on the Godot shape transform
- add a focused ray-query regression test
- update the supported-shapes list

## Why

Godot defines a cylinder around its local origin, while `b3CreateCylinder()` builds upward from its `yOffset`. Passing `-height / 2` preserves Godot's centered shape semantics.

This is a focused replacement extracted from #4.

## Validation

- extension builds from current upstream `main`
- `godot --headless --path test_project --script res://cylinder_test.gd`
- `git diff --check`
- no inferred (`:=`) declarations in the new test
