### PR TITLE
Fix crashes in Box3D when concave polygons are not sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ The structure of this extension is based on [godot-jolt](https://github.com/godo
 - Performance benchmarking and tuning
 - Documentation
 
+## Behavior differences
+
+- **`Area3D` does not detect trimesh or heightmap bodies.** In Box3D a concave shape
+  (`ConcavePolygonShape3D`) or `HeightMapShape3D` can never act as a sensor *visitor* —
+  by design, since testing an arbitrary mesh against a sensor is too expensive. So an
+  `Area3D` silently ignores a body whose shape is a trimesh or heightmap: no
+  `body_entered` / `body_exited` fires for it. This diverges from Godot's built-in
+  physics (and Jolt), which report such a body on the first physics frame. If you need a
+  body to be detected by an area, give it a convex shape. (A trimesh may still be used
+  *as* an `Area3D`'s own shape to detect convex bodies passing through it.)
+
 ## Requirements
 
 - Godot 4.3 or newer

--- a/src/objects/box3d_shaped_object_impl_3d.cpp
+++ b/src/objects/box3d_shaped_object_impl_3d.cpp
@@ -33,15 +33,16 @@ b3ShapeId create_box3d_shape(
 	if (shape == nullptr || p_instance.is_disabled()) {
 		return b3_nullShapeId;
 	}
+
 	const PhysicsServer3D::ShapeType type = shape->get_type();
 	const bool is_concave = (type == PhysicsServer3D::SHAPE_CONCAVE_POLYGON || type == PhysicsServer3D::SHAPE_HEIGHTMAP);
 
 	b3ShapeDef def = b3DefaultShapeDef();
 	def.userData = p_user_data;
 	def.filter = godot_to_b3_filter(p_layer, p_mask);
-
 	def.isSensor = p_is_sensor;
-	def.enableSensorEvents = p_is_sensor || !is_concave; // Concave and not a sensor crashes Box3D
+	// A concave shape may be a sensor, but never a sensor visitor (Box3D can't proxy it).
+	def.enableSensorEvents = p_is_sensor || !is_concave;
 	def.enableContactEvents = !p_is_sensor;
 	def.density = 1.0f;
 	def.baseMaterial = b3DefaultSurfaceMaterial();

--- a/src/objects/box3d_shaped_object_impl_3d.cpp
+++ b/src/objects/box3d_shaped_object_impl_3d.cpp
@@ -33,16 +33,15 @@ b3ShapeId create_box3d_shape(
 	if (shape == nullptr || p_instance.is_disabled()) {
 		return b3_nullShapeId;
 	}
+	const PhysicsServer3D::ShapeType type = shape->get_type();
+	const bool is_concave = (type == PhysicsServer3D::SHAPE_CONCAVE_POLYGON || type == PhysicsServer3D::SHAPE_HEIGHTMAP);
 
 	b3ShapeDef def = b3DefaultShapeDef();
 	def.userData = p_user_data;
 	def.filter = godot_to_b3_filter(p_layer, p_mask);
+
 	def.isSensor = p_is_sensor;
-	// Box3D requires *both* sides of a sensor overlap to opt into sensor events (see
-	// b3ShapeDef::enableSensorEvents doc comment: "This applies to sensors and
-	// non-sensors."), so every shape enables it, not just the sensor side, or Godot's
-	// Area3D body_entered/body_exited would never fire.
-	def.enableSensorEvents = true;
+	def.enableSensorEvents = p_is_sensor || !is_concave; // Concave and not a sensor crashes Box3D
 	def.enableContactEvents = !p_is_sensor;
 	def.density = 1.0f;
 	def.baseMaterial = b3DefaultSurfaceMaterial();
@@ -50,7 +49,6 @@ b3ShapeId create_box3d_shape(
 	def.baseMaterial.restitution = p_restitution;
 
 	const Transform3D& local = p_instance.get_transform();
-	const PhysicsServer3D::ShapeType type = shape->get_type();
 
 	switch (type) {
 		case PhysicsServer3D::SHAPE_SPHERE: {

--- a/src/shapes/box3d_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/box3d_concave_polygon_shape_impl_3d.cpp
@@ -54,16 +54,16 @@ void Box3DConcavePolygonShapeImpl3D::_rebuild_mesh() {
 
 	for (int i = 0; i < face_count; i++) {
 		vertices[i] = godot_to_b3(faces[i]);
-		indices[i] = i;
 		min_point = min_point.min(faces[i]);
 		max_point = max_point.max(faces[i]);
 	}
 
-	// Box3D meshes use the opposite winding order to Godot's concave shapes, so we
-	// reverse each triangle here to make trimesh collision register.
+	// Box3D meshes use the opposite winding order to Godot's concave shapes, so emit
+	// each triangle reversed (v0, v2, v1) to make trimesh collision register.
 	for (int t = 0; t < triangle_count; t++) {
-		indices[t * 3 + 1] = t * 3 + 2;
-		indices[t * 3 + 2] = t * 3 + 1;
+		indices[ t * 3 + 0] =  t * 3 + 0;
+		indices[ t * 3 + 1] =  t * 3 + 2;
+		indices[ t * 3 + 2] =  t * 3 + 1;
 	}
 
 	aabb = AABB(min_point, max_point - min_point);

--- a/src/shapes/box3d_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/box3d_concave_polygon_shape_impl_3d.cpp
@@ -59,6 +59,14 @@ void Box3DConcavePolygonShapeImpl3D::_rebuild_mesh() {
 		max_point = max_point.max(faces[i]);
 	}
 
+	// Box3D meshes use a winding order that is the opposite of what godot's concave shapes use
+	// we need to swap the winding order so trimesh collision works
+	for (int t = 0; t < triangle_count; t++) {
+		indices[t * 3 + 0] = t * 3 + 0;
+		indices[t * 3 + 1] = t * 3 + 2;
+		indices[t * 3 + 2] = t * 3 + 1;
+	}
+
 	aabb = AABB(min_point, max_point - min_point);
 
 	b3MeshDef def = {};

--- a/src/shapes/box3d_concave_polygon_shape_impl_3d.cpp
+++ b/src/shapes/box3d_concave_polygon_shape_impl_3d.cpp
@@ -59,10 +59,9 @@ void Box3DConcavePolygonShapeImpl3D::_rebuild_mesh() {
 		max_point = max_point.max(faces[i]);
 	}
 
-	// Box3D meshes use a winding order that is the opposite of what godot's concave shapes use
-	// we need to swap the winding order so trimesh collision works
+	// Box3D meshes use the opposite winding order to Godot's concave shapes, so we
+	// reverse each triangle here to make trimesh collision register.
 	for (int t = 0; t < triangle_count; t++) {
-		indices[t * 3 + 0] = t * 3 + 0;
 		indices[t * 3 + 1] = t * 3 + 2;
 		indices[t * 3 + 2] = t * 3 + 1;
 	}

--- a/test_project/area_ignores_trimesh_body_test.gd
+++ b/test_project/area_ignores_trimesh_body_test.gd
@@ -1,0 +1,69 @@
+extends SceneTree
+
+# Initialise a scene with an Area3D and two StaticBody3D children: one convex
+# (BoxShape3D) and one concave (ConcavePolygonShape3D / trimesh).
+#
+# An Area3D reports convex bodies overlapping it, but a trimesh body is never a
+# sensor visitor in Box3D, so the area silently ignores it. This is a divergence
+# from current Godot/Jolt behaviour, where a ConcavePolygonShape3D StaticBody
+# triggers a body_entered signal on an Area3D on the first physics frame. This
+# test documents that small discrepancy.
+
+var frames: int = 0
+var convex_entered: bool = false
+var trimesh_entered: bool = false
+
+func _on_body_entered(b: Node3D) -> void:
+	print("Area entered by: ", b.name, " at frame ", frames)
+	if b.name == "ConvexBody":
+		convex_entered = true
+	elif b.name == "TrimeshBody":
+		trimesh_entered = true
+
+func _initialize() -> void:
+	print("Active physics engine setting: ", ProjectSettings.get_setting("physics/3d/physics_engine"))
+
+	var area: Area3D = Area3D.new()
+	var area_shape: CollisionShape3D = CollisionShape3D.new()
+	var area_box: BoxShape3D = BoxShape3D.new()
+	area_box.size = Vector3(6, 6, 6)
+	area_shape.shape = area_box
+	area.add_child(area_shape)
+	area.body_entered.connect(_on_body_entered)
+	root.add_child(area)
+
+	# Positive control: a convex static body inside the area (must be detected).
+	var convex: StaticBody3D = StaticBody3D.new()
+	convex.name = "ConvexBody"
+	var convex_shape: CollisionShape3D = CollisionShape3D.new()
+	var convex_box: BoxShape3D = BoxShape3D.new()
+	convex_box.size = Vector3(1, 1, 1)
+	convex_shape.shape = convex_box
+	convex.add_child(convex_shape)
+	convex.position = Vector3(-1.5, 0, 0)
+	root.add_child(convex)
+
+	# Behavior under test: a trimesh static body inside the area (must be ignored).
+	var trimesh: StaticBody3D = StaticBody3D.new()
+	trimesh.name = "TrimeshBody"
+	var trimesh_shape: CollisionShape3D = CollisionShape3D.new()
+	var trimesh_mesh: BoxMesh = BoxMesh.new()
+	trimesh_mesh.size = Vector3(1, 1, 1)
+	trimesh_shape.shape = trimesh_mesh.create_trimesh_shape()
+	trimesh.add_child(trimesh_shape)
+	trimesh.position = Vector3(1.5, 0, 0)
+	root.add_child(trimesh)
+
+
+func _process(_delta: float) -> bool:
+	frames += 1
+	if frames == 60:
+		print("ConvexBody entered=", convex_entered, "  TrimeshBody entered=", trimesh_entered)
+		if convex_entered and not trimesh_entered:
+			print("RESULT: PASS - area detected the convex body and ignored the trimesh body") # This is a divergence from Godot/Jolt
+		elif not convex_entered:
+			print("RESULT: FAIL - control body not detected; test is broken, not the feature")
+		else:
+			print("RESULT: FAIL - area reported the trimesh body (should be ignored)")
+		quit()
+	return false

--- a/test_project/demo_scene.gd
+++ b/test_project/demo_scene.gd
@@ -14,6 +14,7 @@ func _ready() -> void:
 	_add_camera()
 	_add_light()
 	_add_ground()
+	_add_trimesh_plane()
 	_add_falling_bodies()
 	_add_monitored_area()
 	_add_hinge_door()
@@ -51,6 +52,44 @@ func _add_ground() -> void:
 	ground.add_child(mesh)
 
 	add_child(ground)
+
+
+func _add_trimesh_plane() -> void:
+	var plane_mesh: PlaneMesh = PlaneMesh.new()
+	plane_mesh.size = Vector2(6, 6)
+
+	var body: StaticBody3D = StaticBody3D.new()
+	body.name = "TrimeshFloor"
+	body.position = Vector3(0, 2.5, 4)
+
+	var collision: CollisionShape3D = CollisionShape3D.new()
+	collision.shape = plane_mesh.create_trimesh_shape()
+	body.add_child(collision)
+
+	var mesh: MeshInstance3D = MeshInstance3D.new()
+	mesh.mesh = plane_mesh
+	var material: StandardMaterial3D = StandardMaterial3D.new()
+	material.albedo_color = Color(0.85, 0.45, 0.2)
+	material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	mesh.material_override = material
+	body.add_child(mesh)
+
+	add_child(body)
+
+	var dropper: RigidBody3D = RigidBody3D.new()
+	dropper.name = "TrimeshDropper"
+	dropper.position = Vector3(0, 8, 4)
+	var dropper_shape: CollisionShape3D = CollisionShape3D.new()
+	var dropper_box: BoxShape3D = BoxShape3D.new()
+	dropper_box.size = Vector3(0.8, 0.8, 0.8)
+	dropper_shape.shape = dropper_box
+	dropper.add_child(dropper_shape)
+	var dropper_mesh: MeshInstance3D = MeshInstance3D.new()
+	var dropper_box_mesh: BoxMesh = BoxMesh.new()
+	dropper_box_mesh.size = dropper_box.size
+	dropper_mesh.mesh = dropper_box_mesh
+	dropper.add_child(dropper_mesh)
+	add_child(dropper)
 
 
 func _add_falling_bodies() -> void:

--- a/test_project/trimesh_area_detects_body_test.gd
+++ b/test_project/trimesh_area_detects_body_test.gd
@@ -1,0 +1,61 @@
+extends SceneTree
+
+# A trimesh (ConcavePolygonShape3D) is allowed to act as an Area3D *sensor*: it may
+# detect convex bodies that pass through it. This exercises Box3D's mesh-as-sensor
+# path (b3OverlapSensor with a mesh sensor + a convex visitor proxy), which is
+# distinct from mesh-as-visitor (unsupported by box3D)
+
+var frames: int = 0
+var body: RigidBody3D
+var area: Area3D
+var entered: bool = false
+var exited: bool = false
+
+func _on_body_entered(b: Node3D) -> void:
+	entered = true
+	print("Trimesh area entered by: ", b.name)
+
+func _on_body_exited(b: Node3D) -> void:
+	exited = true
+	print("Trimesh area exited by: ", b.name)
+
+func _initialize() -> void:
+	print("Active physics engine setting: ", ProjectSettings.get_setting("physics/3d/physics_engine"))
+
+	# Area3D whose own shape is a trimesh volume.
+	area = Area3D.new()
+	area.name = "TrimeshArea"
+	var area_shape: CollisionShape3D = CollisionShape3D.new()
+	var area_mesh: BoxMesh = BoxMesh.new()
+	area_mesh.size = Vector3(4, 4, 4)
+	area_shape.shape = area_mesh.create_trimesh_shape()
+	area.add_child(area_shape)
+	area.position = Vector3(0, 0, 0)
+	area.body_entered.connect(_on_body_entered)
+	area.body_exited.connect(_on_body_exited)
+	root.add_child(area)
+
+	# Convex dynamic body travelling straight down through the area.
+	body = RigidBody3D.new()1
+	body.name = "FallingBody"
+	body.gravity_scale = 0.0
+	var body_shape: CollisionShape3D = CollisionShape3D.new()
+	var box: BoxShape3D = BoxShape3D.new()
+	box.size = Vector3(0.6, 0.6, 0.6)
+	body_shape.shape = box
+	body.add_child(body_shape)
+	body.position = Vector3(0, 10, 0)
+	body.linear_velocity = Vector3(0, -5, 0)
+	root.add_child(body)
+
+
+func _process(_delta: float) -> bool:
+	frames += 1
+	if frames == 600:
+		print("Entered: ", entered, " Exited: ", exited)
+		if entered and exited:
+			print("RESULT: PASS - trimesh area detected the convex body entering and exiting")
+		else:
+			print("RESULT: FAIL - trimesh area did not report enter/exit for the convex body")
+		quit()
+	return false

--- a/test_project/trimesh_area_detects_body_test.gd
+++ b/test_project/trimesh_area_detects_body_test.gd
@@ -36,7 +36,7 @@ func _initialize() -> void:
 	root.add_child(area)
 
 	# Convex dynamic body travelling straight down through the area.
-	body = RigidBody3D.new()1
+	body = RigidBody3D.new()
 	body.name = "FallingBody"
 	body.gravity_scale = 0.0
 	var body_shape: CollisionShape3D = CollisionShape3D.new()

--- a/test_project/trimesh_collision_test.gd
+++ b/test_project/trimesh_collision_test.gd
@@ -1,0 +1,47 @@
+extends SceneTree
+
+# Tests that a dynamic body must rest ON a trimesh floor, not tunnel
+# through it.
+
+var frames: int = 0
+var body: RigidBody3D
+
+func _initialize() -> void:
+	print("Active physics engine setting: ", ProjectSettings.get_setting("physics/3d/physics_engine"))
+
+	# Trimesh floor: a thin box turned into a ConcavePolygonShape3D so we get Godot's
+	# real triangle winding rather than a hand-rolled one.
+	var floor_body: StaticBody3D = StaticBody3D.new()
+	var floor_shape: CollisionShape3D = CollisionShape3D.new()
+	var floor_mesh: BoxMesh = BoxMesh.new()
+	floor_mesh.size = Vector3(10, 1, 10)
+	floor_shape.shape = floor_mesh.create_trimesh_shape()
+	floor_body.add_child(floor_shape)
+	floor_body.position = Vector3(0, -0.5, 0)  # top face at y = 0
+	root.add_child(floor_body)
+
+	body = RigidBody3D.new()
+	var body_shape: CollisionShape3D = CollisionShape3D.new()
+	var box: BoxShape3D = BoxShape3D.new()
+	box.size = Vector3(1, 1, 1)
+	body_shape.shape = box
+	body.add_child(body_shape)
+	body.position = Vector3(0, 5, 0)
+	root.add_child(body)
+
+	print("Initial body Y: ", body.position.y)
+
+
+func _process(_delta: float) -> bool:
+	frames += 1
+	if frames == 180:
+		var y: float = body.global_position.y
+		print("Body Y after 180 physics frames: ", y)
+		print("Body linear velocity: ", body.linear_velocity)
+		# Box (half-height 0.5) resting on floor top (y = 0) settles near y = 0.5.
+		if y > 0.2 and y < 1.0:
+			print("RESULT: PASS - body came to rest on the trimesh floor")
+		else:
+			print("RESULT: FAIL - body did not rest on the trimesh floor (tunneled or floated)")
+		quit()
+	return false


### PR DESCRIPTION
 Fixes two bugs that made trimesh (ConcavePolygonShape3D) collision unusable with the Box3D integration:

  1. Crash when a trimesh body was present in a scene with an Area3D.
  2. Fall-through dynamic bodies passed straight through trimesh surfaces.
  
  
1. Crash concave shapes used as sensor "visitors"
Box3D's sensor pass builds a convex shape proxy of every shape overlapping a sensor. Concave shapes (mesh/heightfield) have no convex proxy representation, so this asserts and crashes. The integration was enabling sensor events on every shape, which made concave bodies eligible as sensor visitors.
→ Only enable sensor events on a concave shape when it is itself a sensor, so a mesh is never treated as a visitor. (Confirmed with the Box3D author: "meshes should never be visitors.")

2. Fall-through reversed triangle winding
Godot's concave shapes use the opposite front-face winding to Box3D's one-sided meshes, so triangle normals faced away from incoming bodies and contacts were rejected.
→ Reverse each triangle's winding when building the Box3D mesh, aligning the collidable face with Godot's.

Testing

Added a code-generated trimesh plane + a dropped box to demo_scene.gd as a live check the box now lands on the trimesh, and the scene no longer crashes with the Area3D present.

 Fixes two bugs that made trimesh (ConcavePolygonShape3D) collision unusable with the Box3D integration:

  1. Crash when a trimesh body was present in a scene with an Area3D.
  2. Fall-through dynamic bodies passed straight through trimesh surfaces.

  Steps to reproduce

  Add a MeshInstance3D (e.g. a plane) with a trimesh StaticBody3D child to a scene that also contains a monitored Area3D, then run it. Box3D crashes on the first physics step (signal 5 / failed assertion). Removing the crash reveals a second issue: rigid bodies fall straight through the trimesh instead of landing on it.
