### PR TITLE
Free cleared joint RID placeholders

### DIFF
--- a/scripts/run_headless_tests.sh
+++ b/scripts/run_headless_tests.sh
@@ -44,14 +44,30 @@ printf '%s\n' 'res://addons/godot-box3d/godot-box3d.gdextension' > "$godot_metad
 
 backend_test="backend_activation_test.gd"
 
-printf '\n== %s ==\n' "$backend_test"
-"$godot_bin" --headless --path "$repo_root/test_project" --script "res://$backend_test"
+run_test() {
+	local test_script="$1"
+	local test_output
+	local test_status=0
+
+	printf '\n== %s ==\n' "$test_script"
+	test_output="$("$godot_bin" --headless --path "$repo_root/test_project" --script "res://$test_script" 2>&1)" || test_status=$?
+	printf '%s\n' "$test_output"
+
+	if (( test_status != 0 )); then
+		return "$test_status"
+	fi
+	if [[ "$test_output" == *"RIDs in Godot Box3D were found to not have been freed"* ]]; then
+		printf 'ERROR: %s leaked one or more Box3D RIDs.\n' "$test_script" >&2
+		return 1
+	fi
+}
+
+run_test "$backend_test"
 
 for test_path in "$repo_root"/test_project/*_test.gd; do
 	test_script="${test_path##*/}"
 	if [[ "$test_script" == "$backend_test" ]]; then
 		continue
 	fi
-	printf '\n== %s ==\n' "$test_script"
-	"$godot_bin" --headless --path "$repo_root/test_project" --script "res://$test_script"
+	run_test "$test_script"
 done

--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -1198,8 +1198,12 @@ bool Box3DPhysicsServer3D::_soft_body_is_point_pinned(const RID& p_body, int32_t
 void Box3DPhysicsServer3D::_free_rid(const RID& p_rid) {
 	// Joints and shapes free before bodies/areas that reference them; bodies/areas free
 	// before shapes they hold (mirrors JoltPhysicsServer3DExtension::_free_rid's ordering).
-	if (Box3DJointImpl3D* joint = joint_owner.get_or_null(p_rid)) {
-		memdelete(joint);
+	if (joint_owner.owns(p_rid)) {
+		if (Box3DJointImpl3D* joint = joint_owner.get_or_null(p_rid)) {
+			memdelete(joint);
+		}
+		// _joint_clear() keeps a null placeholder so the RID can be rebound.
+		// Free the owned RID even when no concrete joint remains.
 		joint_owner.free(p_rid);
 		return;
 	}


### PR DESCRIPTION
## Summary

- Always free a joint owner RID even when _joint_clear() has already replaced the concrete joint with a null placeholder.
- Make the headless runner fail on the extension's exact leaked-RID warning so this lifecycle regression cannot remain hidden behind a passing script exit code.

## Why

Joint teardown can clear the concrete joint before _free_rid() runs. The previous get_or_null() condition then skipped joint_owner.free(), leaving one RID behind. The existing joint test still reported PASS, but Godot emitted a warning that one Box3D RID had not been freed.

The runner guard is deliberately limited to that Box3D-specific warning; ordinary unsupported-parameter warnings remain visible without failing the suite.

## Validation

- Clean CMake build against the original erincatto/box3d submodule revision.
- Full scripts/run_headless_tests.sh suite passes with Godot 4.7.
- Existing joint_test.gd completes without the leaked-RID warning after the fix.
- bash -n and shellcheck pass for the runner.