### PR TITLE
Honor excluded RIDs in direct queries

### DIFF
--- a/src/spaces/box3d_physics_direct_space_state_3d.cpp
+++ b/src/spaces/box3d_physics_direct_space_state_3d.cpp
@@ -155,6 +155,7 @@ bool Box3DPhysicsDirectSpaceState3D::_intersect_ray(
 	ERR_FAIL_NULL_V(space, false);
 
 	Box3DQueryFilter3D filter(p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
+	filter.direct_state = this;
 
 	RayContext context;
 	context.filter = &filter;
@@ -193,6 +194,7 @@ int32_t Box3DPhysicsDirectSpaceState3D::_intersect_point(
 	ERR_FAIL_NULL_V(space, 0);
 
 	Box3DQueryFilter3D filter(p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
+	filter.direct_state = this;
 
 	const b3Vec3 point = godot_to_b3(p_position);
 	b3ShapeProxy proxy;
@@ -231,6 +233,7 @@ int32_t Box3DPhysicsDirectSpaceState3D::_intersect_shape(
 	}
 
 	Box3DQueryFilter3D filter(p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
+	filter.direct_state = this;
 
 	OverlapContext context;
 	context.filter = &filter;
@@ -266,6 +269,7 @@ bool Box3DPhysicsDirectSpaceState3D::_cast_motion(
 	}
 
 	Box3DQueryFilter3D filter(p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
+	filter.direct_state = this;
 
 	RayContext context;
 	context.filter = &filter;
@@ -309,6 +313,7 @@ bool Box3DPhysicsDirectSpaceState3D::_collide_shape(
 	}
 
 	Box3DQueryFilter3D filter(p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
+	filter.direct_state = this;
 
 	CollideShapeContext context;
 	context.filter = &filter;
@@ -343,6 +348,7 @@ bool Box3DPhysicsDirectSpaceState3D::_rest_info(
 	}
 
 	Box3DQueryFilter3D filter(p_collision_mask, p_collide_with_bodies, p_collide_with_areas);
+	filter.direct_state = this;
 
 	RayContext context;
 	context.filter = &filter;

--- a/src/spaces/box3d_query_filter_3d.hpp
+++ b/src/spaces/box3d_query_filter_3d.hpp
@@ -2,6 +2,7 @@
 
 #include "../misc/type_conversions.hpp"
 
+#include <godot_cpp/classes/physics_direct_space_state3d_extension.hpp>
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/variant/rid.hpp>
 
@@ -16,6 +17,7 @@ using namespace godot;
 struct Box3DQueryFilter3D {
 	b3QueryFilter filter = godot_to_b3_query_filter(UINT32_MAX);
 	HashSet<RID> exclude;
+	const PhysicsDirectSpaceState3DExtension* direct_state = nullptr;
 	bool collide_with_bodies = true;
 	bool collide_with_areas = false;
 
@@ -28,5 +30,7 @@ struct Box3DQueryFilter3D {
 
 	void set_collision_mask(uint32_t p_collision_mask) { filter = godot_to_b3_query_filter(p_collision_mask); }
 
-	bool should_exclude(const RID& p_rid) const { return exclude.has(p_rid); }
+	bool should_exclude(const RID& p_rid) const {
+		return exclude.has(p_rid) || (direct_state != nullptr && direct_state->is_body_excluded_from_query(p_rid));
+	}
 };

--- a/test_project/tests/collide_shape_test.gd
+++ b/test_project/tests/collide_shape_test.gd
@@ -8,7 +8,7 @@ func _initialize() -> void:
 
 
 func _run() -> void:
-	_make_box_body(Vector3(0, 0, 0), 4)
+	var excluded_body: StaticBody3D = _make_box_body(Vector3(0, 0, 0), 4)
 	_make_box_body(Vector3(1.2, 0, 0), 4)
 	_make_box_body(Vector3(2.4, 0, 0), 4)
 	_make_box_body(Vector3(0, 0, 20), 8)
@@ -37,6 +37,11 @@ func _run() -> void:
 
 	var other_layer: Array[Vector3] = state.collide_shape(_make_query(Vector3(0, 0, 20), 8), 8)
 	_check(not other_layer.is_empty(), "a matching collision mask still reports")
+
+	var excluded_query: PhysicsShapeQueryParameters3D = _make_query(Vector3(0, 0, 0), 4)
+	excluded_query.exclude = [excluded_body.get_rid()]
+	var excluded: Array[Vector3] = state.collide_shape(excluded_query, 8)
+	_check(excluded.is_empty(), "excluded body RIDs are ignored")
 
 	if failures == 0:
 		print("RESULT: PASS - collide_shape reports overlapping shape points")


### PR DESCRIPTION
## Summary

- connect Box3D direct-query filters to Godot's active RID exclusion list
- apply the exclusion check to ray, point, shape, motion, collision, and rest queries
- add a focused `collide_shape` regression assertion

## Why

Box3D has no native per-query RID exclusion list. The callback filter already supported an internal exclude set, but public direct-query exclusions were never passed into it, so excluded bodies could still be reported.

## Testing

- full headless test suite passes
- focused `collide_shape_test.gd` passes with the excluded RID assertion
- broader physics contract now passes both direct-query exclusion checks; its three unrelated pre-existing motion/damping failures remain unchanged
