### PR TITLE
Handle PinJoint3D placeholder setup without false errors

### DIFF
--- a/scripts/run_headless_tests.sh
+++ b/scripts/run_headless_tests.sh
@@ -86,6 +86,15 @@ run_test() {
 		test_status=1
 	fi
 
+	if (( test_status == 0 )) && {
+		[[ "$test_output" == *"ERROR:"* ]] ||
+			[[ "$test_output" == *"SCRIPT ERROR:"* ]] ||
+			[[ "$test_output" == *"RESULT: FAIL"* ]]
+	}; then
+		printf 'ERROR: %s emitted an unexpected error or failure marker.\n' "$test_script" >&2
+		test_status=1
+	fi
+
 	if (( test_status == 0 )); then
 		passed_tests+=("$test_script")
 	else

--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -939,12 +939,17 @@ void Box3DPhysicsServer3D::_joint_clear(const RID& p_joint) {
 }
 
 void Box3DPhysicsServer3D::_joint_make_pin(const RID& p_joint, const RID& p_body_a, const Vector3& p_local_a, const RID& p_body_b, const Vector3& p_local_b) {
+	ERR_FAIL_COND(!joint_owner.owns(p_joint));
 	_joint_clear(p_joint);
 
 	Box3DBodyImpl3D* body_a = body_owner.get_or_null(p_body_a);
 	Box3DBodyImpl3D* body_b = body_owner.get_or_null(p_body_b);
-	ERR_FAIL_NULL(body_a);
-	ERR_FAIL_NULL(body_b);
+	// PinJoint3D reconfigures itself as each NodePath property is assigned. During
+	// that normal setup sequence one body RID is temporarily empty, so retain the
+	// valid placeholder until both endpoints are available.
+	if (body_a == nullptr || body_b == nullptr) {
+		return;
+	}
 
 	auto* joint = memnew(Box3DPinJointImpl3D(body_a, body_b, Transform3D(Basis(), p_local_a), Transform3D(Basis(), p_local_b)));
 	joint->set_rid(p_joint);
@@ -953,7 +958,12 @@ void Box3DPhysicsServer3D::_joint_make_pin(const RID& p_joint, const RID& p_body
 }
 
 void Box3DPhysicsServer3D::_pin_joint_set_param(const RID& p_joint, PhysicsServer3D::PinJointParam p_param, double p_value) {
-	auto* joint = dynamic_cast<Box3DPinJointImpl3D*>(joint_owner.get_or_null(p_joint));
+	ERR_FAIL_COND(!joint_owner.owns(p_joint));
+	Box3DJointImpl3D* base_joint = joint_owner.get_or_null(p_joint);
+	if (base_joint == nullptr) {
+		return;
+	}
+	auto* joint = dynamic_cast<Box3DPinJointImpl3D*>(base_joint);
 	ERR_FAIL_NULL(joint);
 	joint->set_param(p_param, p_value);
 }
@@ -1139,8 +1149,11 @@ int32_t Box3DPhysicsServer3D::_joint_get_solver_priority(const RID& p_joint) con
 }
 
 void Box3DPhysicsServer3D::_joint_disable_collisions_between_bodies(const RID& p_joint, bool p_disable) {
+	ERR_FAIL_COND(!joint_owner.owns(p_joint));
 	Box3DJointImpl3D* joint = joint_owner.get_or_null(p_joint);
-	ERR_FAIL_NULL(joint);
+	if (joint == nullptr) {
+		return;
+	}
 	joint->set_collision_disabled(p_disable);
 }
 


### PR DESCRIPTION
## Summary

- accept the valid joint placeholder created while `PinJoint3D` assigns its endpoint paths
- continue rejecting unknown joint RIDs and wrong concrete joint types
- fail the headless runner when Godot prints an engine/script error or `RESULT: FAIL` despite returning exit code 0

## Why

`pin_joint_anchor_test.gd` currently reports PASS and exits 0 while normal node setup emits five engine errors: one incomplete body endpoint, three parameter writes to the placeholder, and one collision-disable write. The implementation already treats early anchor writes as normal placeholder setup; this makes the remaining writes consistent and prevents similar output from being counted as green later.

## Validation

- all 19 headless physics tests pass
- the pin-joint test no longer emits engine errors
- the runner still permits the existing documented unsupported-parameter warnings
