### PR TITLE
Report multi-shape collision indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The trade is structural. `PhysicsServer3D` has no entry point for `b3World_Explo
 
 Use this if you have an existing project or want stock nodes and addons to work. Use box3d-godot if you want Box3D's own feature surface and don't mind building scenes around its nodes. Neither is production-ready.
 
-**Currently behind box3d-godot on:** *joint types, ConeTwist and 6DOF, per-shape indices in query results, profiling, and platforms.*
+**Currently behind box3d-godot on:** *joint types, ConeTwist and 6DOF, profiling, and platforms.*
 
 ## What works
 
@@ -48,10 +48,11 @@ Use this if you have an existing project or want stock nodes and addons to work.
 - Direct space state queries: ray casts, point and shape intersection, shape casts (`cast_motion`), `collide_shape`, and `rest_info`
 - `body_test_motion`, so `CharacterBody3D` and `move_and_slide()` work
 - Contact monitoring, so `RigidBody3D` reports real contact points, normals, and impulses
+- Queries and contact results report per-shape indices for multi-shape bodies
 - Per-pair collision exceptions
 - Joints: pin, hinge, and slider (pin anchors can be moved after creation)
 - Multithreaded solver: the worker count auto-detects physical cores and can be overridden with the `physics/box3d/worker_count` project setting (results are deterministic across worker counts)
-- A test project with a demo hub, a deterministic benchmark, and 19 headless regression tests
+- A test project with a demo hub, a deterministic benchmark, and a headless regression suite
 
 ## What's left to do
 
@@ -59,7 +60,6 @@ Use this if you have an existing project or want stock nodes and addons to work.
 - ConeTwist joints
 - `Generic6DOFJoint3D` (Box3D has no per-axis lock/limit/motor constraint, so there is no faithful mapping; use `PinJoint3D`, `HingeJoint3D`, or `SliderJoint3D` instead)
 - `SoftBody3D`
-- Per-shape indices in query and contact results (multi-shape bodies always report shape 0)
 - Solver profiling
 - macOS support: universal binaries and notarization (arm64 builds compile but are untested)
 - More platforms and architectures (currently Linux and Windows)
@@ -155,7 +155,7 @@ cmake --build build-win --parallel
 GODOT_BIN=/path/to/godot scripts/run_headless_tests.sh
 ```
 
-The runner builds the extension, registers it, checks the Box3D backend actually loaded, then runs 19 headless regression tests. It exits nonzero if a test fails or leaks a Box3D RID. `GODOT_BIN` can be omitted when a suitable `godot` is on `PATH`.
+The runner builds the extension, registers it, checks the Box3D backend actually loaded, then runs the headless regression suite. It exits nonzero if a test fails or leaks a Box3D RID. `GODOT_BIN` can be omitted when a suitable `godot` is on `PATH`.
 
 ## Contributing
 

--- a/docs/behavior-differences.md
+++ b/docs/behavior-differences.md
@@ -34,10 +34,6 @@ Box3D uses `sqrt(a * b)` for friction and `max(a, b)` for restitution. Godot's b
 
 Materials tuned against Godot's defaults will not feel the same, so a port usually needs its friction values revisited.
 
-## Multi-shape bodies report shape 0
-
-Query and contact results do not carry per-shape indices yet, so a body with several shapes always reports `shape = 0`. Code that branches on which shape was hit needs separate bodies for now.
-
 ## Ignored joint parameters
 
 Godot's joint API exposes parameters Box3D has no equivalent for, including `HingeJoint3D`'s `LIMIT_RELAXATION` and `LIMIT_SOFTNESS`, `PinJoint3D`'s `IMPULSE_CLAMP`, and most of `SliderJoint3D`'s per-axis tuning (Box3D's prismatic joint is a pure 1-DOF slider).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -38,4 +38,4 @@ Neither is production-ready, and both say so.
 
 ## Where this project is behind
 
-Joint types, ConeTwist and 6DOF, per-shape indices in query results, profiling, and platforms.
+Joint types, ConeTwist and 6DOF, profiling, and platforms.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ Box3D is worth trying because of where it came from. [Erin Catto](https://x.com/
 - Direct space state queries: ray casts, point and shape intersection, shape casts (`cast_motion`), `collide_shape`, and `rest_info`
 - `body_test_motion`, so `CharacterBody3D` and `move_and_slide()` work
 - Contact monitoring, so `RigidBody3D` reports real contact points, normals, and impulses
+- Queries and contact results report per-shape indices for multi-shape bodies
 - Per-pair collision exceptions
 - Joints: pin, hinge, and slider (pin anchors can be moved after creation)
 - Multithreaded solver: auto-detects physical cores, overridable via `physics/box3d/worker_count`
@@ -41,7 +42,6 @@ Box3D is worth trying because of where it came from. [Erin Catto](https://x.com/
 - ConeTwist joints
 - `Generic6DOFJoint3D` (Box3D has no per-axis lock/limit/motor constraint, so there is no faithful mapping)
 - `SoftBody3D`
-- Per-shape indices in query and contact results (multi-shape bodies always report shape 0)
 - Solver profiling
 - macOS universal binaries and notarization
 

--- a/src/objects/box3d_body_impl_3d.cpp
+++ b/src/objects/box3d_body_impl_3d.cpp
@@ -404,10 +404,12 @@ void Box3DBodyImpl3D::refresh_contacts() {
 		auto* object_a = static_cast<Box3DShapedObjectImpl3D*>(b3Body_GetUserData(body_a));
 		const bool self_is_a = object_a == this;
 		const b3BodyId other_id = self_is_a ? body_b : body_a;
+		const b3ShapeId self_shape_id = self_is_a ? pair.shapeIdA : pair.shapeIdB;
+		const b3ShapeId other_shape_id = self_is_a ? pair.shapeIdB : pair.shapeIdA;
 
 		// Areas share the userData slot as a sibling class, so a static_cast would yield garbage.
-		auto* other = dynamic_cast<Box3DBodyImpl3D*>(
-				static_cast<Box3DShapedObjectImpl3D*>(b3Body_GetUserData(other_id)));
+		auto* other_object = static_cast<Box3DShapedObjectImpl3D*>(b3Body_GetUserData(other_id));
+		auto* other = dynamic_cast<Box3DBodyImpl3D*>(other_object);
 
 		const b3Vec3 other_center = b3Body_GetWorldCenter(other_id);
 
@@ -432,6 +434,8 @@ void Box3DBodyImpl3D::refresh_contacts() {
 				contact.impulse = normal * (real_t)point.totalNormalImpulse;
 				contact.local_velocity = b3_to_godot(b3Body_GetWorldPointVelocity(body_id, self_point));
 				contact.collider_position = b3_to_godot(other_point);
+				contact.local_shape = find_shape_index(self_shape_id);
+				contact.collider_shape = other_object != nullptr ? other_object->find_shape_index(other_shape_id) : -1;
 				if (other != nullptr) {
 					contact.collider_velocity = b3_to_godot(b3Body_GetWorldPointVelocity(other_id, other_point));
 					contact.collider_rid = other->get_rid();

--- a/src/objects/box3d_body_impl_3d.hpp
+++ b/src/objects/box3d_body_impl_3d.hpp
@@ -24,6 +24,8 @@ struct Box3DContactPoint3D {
 	Vector3 collider_velocity;
 	RID collider_rid;
 	uint64_t collider_instance_id = 0;
+	int32_t local_shape = -1;
+	int32_t collider_shape = -1;
 };
 
 // RigidBody-facing wrapper: static/kinematic/dynamic bodies. Box3D requires a valid world

--- a/src/objects/box3d_physics_direct_body_state_3d.cpp
+++ b/src/objects/box3d_physics_direct_body_state_3d.cpp
@@ -186,8 +186,9 @@ Vector3 Box3DPhysicsDirectBodyState3D::_get_contact_impulse(int32_t p_index) con
 }
 
 int32_t Box3DPhysicsDirectBodyState3D::_get_contact_local_shape(int32_t p_index) const {
-	// Shape userData carries no stable index yet, so multi-shape bodies always report 0.
-	return 0;
+	const LocalVector<Box3DContactPoint3D>& contacts = body->get_contacts();
+	ERR_FAIL_INDEX_V(p_index, (int32_t)contacts.size(), -1);
+	return contacts[p_index].local_shape;
 }
 
 Vector3 Box3DPhysicsDirectBodyState3D::_get_contact_local_velocity_at_position(int32_t p_index) const {
@@ -225,8 +226,9 @@ Object* Box3DPhysicsDirectBodyState3D::_get_contact_collider_object(int32_t p_in
 }
 
 int32_t Box3DPhysicsDirectBodyState3D::_get_contact_collider_shape(int32_t p_index) const {
-	// See _get_contact_local_shape.
-	return 0;
+	const LocalVector<Box3DContactPoint3D>& contacts = body->get_contacts();
+	ERR_FAIL_INDEX_V(p_index, (int32_t)contacts.size(), -1);
+	return contacts[p_index].collider_shape;
 }
 
 Vector3 Box3DPhysicsDirectBodyState3D::_get_contact_collider_velocity_at_position(int32_t p_index) const {

--- a/src/objects/box3d_shaped_object_impl_3d.cpp
+++ b/src/objects/box3d_shaped_object_impl_3d.cpp
@@ -260,6 +260,17 @@ b3ShapeId Box3DShapedObjectImpl3D::get_shape_id(int32_t p_index) const {
 	return shapes[p_index].get_shape_id();
 }
 
+int32_t Box3DShapedObjectImpl3D::find_shape_index(b3ShapeId p_shape_id) const {
+	// LocalVector can relocate its elements, so resolve the stable Box3D ID rather than
+	// storing shape-instance pointers as user data.
+	for (uint32_t i = 0; i < shapes.size(); i++) {
+		if (shapes[i].has_shape_id() && B3_ID_EQUALS(shapes[i].get_shape_id(), p_shape_id)) {
+			return (int32_t)i;
+		}
+	}
+	return -1;
+}
+
 bool Box3DShapedObjectImpl3D::has_shape_id(int32_t p_index) const {
 	ERR_FAIL_INDEX_V(p_index, (int32_t)shapes.size(), false);
 	return shapes[p_index].has_shape_id();
@@ -343,7 +354,7 @@ void Box3DShapedObjectImpl3D::_create_shape_instance(Box3DShapeInstance3D& p_ins
 	if (p_instance.has_shape_id() || !has_body_id()) {
 		return;
 	}
-	const b3ShapeId shape_id = create_box3d_shape(body_id, p_instance, collision_layer, collision_mask, _is_sensor_body(), &p_instance, _get_shape_friction(), _get_shape_restitution());
+	const b3ShapeId shape_id = create_box3d_shape(body_id, p_instance, collision_layer, collision_mask, _is_sensor_body(), this, _get_shape_friction(), _get_shape_restitution());
 	p_instance.set_shape_id(shape_id);
 }
 

--- a/src/objects/box3d_shaped_object_impl_3d.hpp
+++ b/src/objects/box3d_shaped_object_impl_3d.hpp
@@ -46,6 +46,8 @@ public:
 
 	b3ShapeId get_shape_id(int32_t p_index) const;
 
+	int32_t find_shape_index(b3ShapeId p_shape_id) const;
+
 	bool has_shape_id(int32_t p_index) const;
 
 	void set_shape_transform(int32_t p_index, const Transform3D& p_transform);

--- a/src/spaces/box3d_physics_direct_space_state_3d.cpp
+++ b/src/spaces/box3d_physics_direct_space_state_3d.cpp
@@ -55,7 +55,7 @@ bool overlap_result_fcn(b3ShapeId p_shape_id, void* p_context) {
 	PhysicsServer3DExtensionShapeResult& result = ctx->results[ctx->count];
 	result.rid = object->get_rid();
 	result.collider_id = object->get_instance_id();
-	result.shape = 0;
+	result.shape = object->find_shape_index(p_shape_id);
 	ctx->count++;
 	return true;
 }
@@ -180,7 +180,7 @@ bool Box3DPhysicsDirectSpaceState3D::_intersect_ray(
 	p_result->normal = b3_to_godot(context.normal);
 	p_result->rid = object->get_rid();
 	p_result->collider_id = object->get_instance_id();
-	p_result->shape = 0;
+	p_result->shape = object->find_shape_index(context.shape_id);
 	return true;
 }
 
@@ -369,7 +369,7 @@ bool Box3DPhysicsDirectSpaceState3D::_rest_info(
 	p_info->normal = b3_to_godot(context.normal);
 	p_info->rid = object->get_rid();
 	p_info->collider_id = object->get_instance_id();
-	p_info->shape = 0;
+	p_info->shape = object->find_shape_index(context.shape_id);
 
 	auto* body = dynamic_cast<Box3DBodyImpl3D*>(object);
 	if (body != nullptr) {
@@ -458,7 +458,7 @@ bool Box3DPhysicsDirectSpaceState3D::test_body_motion(
 		collision.normal = b3_to_godot(context.normal);
 		collision.collider = other->get_rid();
 		collision.collider_id = other->get_instance_id();
-		collision.collider_shape = 0;
+		collision.collider_shape = other->find_shape_index(context.shape_id);
 		collision.depth = 0.0f;
 		p_result->collision_count = 1;
 	}

--- a/test_project/tests/multi_shape_index_test.gd
+++ b/test_project/tests/multi_shape_index_test.gd
@@ -1,0 +1,117 @@
+extends SceneTree
+
+var failures: int = 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var query_target: StaticBody3D = StaticBody3D.new()
+	query_target.name = "MultiShapeQueryTarget"
+	_add_box(query_target, Vector3(-4, 0, 0), Vector3(2, 2, 2), true)
+	_add_box(query_target, Vector3(4, 0, 0), Vector3(2, 2, 2), false)
+	root.add_child(query_target)
+
+	var ground: StaticBody3D = StaticBody3D.new()
+	ground.name = "MultiShapeGround"
+	ground.position = Vector3(0, -0.5, 20)
+	_add_box(ground, Vector3(-8, 0, 0), Vector3(6, 1, 6), true)
+	_add_box(ground, Vector3.ZERO, Vector3(6, 1, 6), false)
+	root.add_child(ground)
+
+	var body: RigidBody3D = RigidBody3D.new()
+	body.name = "MultiShapeBody"
+	body.position = Vector3(0, 3, 20)
+	body.contact_monitor = true
+	body.max_contacts_reported = 8
+	body.can_sleep = false
+	_add_sphere(body, Vector3(8, 0, 0), true)
+	_add_sphere(body, Vector3.ZERO, false)
+	root.add_child(body)
+
+	await physics_frame
+	await physics_frame
+
+	var space_state: PhysicsDirectSpaceState3D = root.world_3d.direct_space_state
+	var ray_query: PhysicsRayQueryParameters3D = PhysicsRayQueryParameters3D.create(
+		Vector3(4, 3, 0),
+		Vector3(4, -3, 0),
+	)
+	var ray_hit: Dictionary = space_state.intersect_ray(ray_query)
+	_check(ray_hit.get("rid") == query_target.get_rid(), "ray query hits the multi-shape body")
+	_check(ray_hit.get("shape", -1) == 1, "ray query reports the active second shape")
+
+	var point_query: PhysicsPointQueryParameters3D = PhysicsPointQueryParameters3D.new()
+	point_query.position = Vector3(4, 0, 0)
+	var point_hit: Dictionary = _find_rid(space_state.intersect_point(point_query), query_target.get_rid())
+	_check(not point_hit.is_empty(), "point query hits the multi-shape body")
+	_check(point_hit.get("shape", -1) == 1, "point query reports the active second shape")
+
+	var query_box: BoxShape3D = BoxShape3D.new()
+	query_box.size = Vector3(0.5, 0.5, 0.5)
+	var shape_query: PhysicsShapeQueryParameters3D = PhysicsShapeQueryParameters3D.new()
+	shape_query.shape = query_box
+	shape_query.transform = Transform3D(Basis(), Vector3(4, 0, 0))
+	var shape_hit: Dictionary = _find_rid(space_state.intersect_shape(shape_query), query_target.get_rid())
+	_check(not shape_hit.is_empty(), "shape query hits the multi-shape body")
+	_check(shape_hit.get("shape", -1) == 1, "shape query reports the active second shape")
+
+	for frame in 180:
+		await physics_frame
+
+	var body_state: PhysicsDirectBodyState3D = PhysicsServer3D.body_get_direct_state(body.get_rid())
+	var contact_index: int = _find_contact(body_state, ground.get_rid())
+	_check(contact_index >= 0, "multi-shape body reports its resting ground contact")
+	if contact_index >= 0:
+		_check(body_state.get_contact_local_shape(contact_index) == 1, "contact reports the body's active second shape")
+		_check(body_state.get_contact_collider_shape(contact_index) == 1, "contact reports the ground's active second shape")
+
+	if failures == 0:
+		print("RESULT: PASS - queries and contacts report multi-shape indices")
+	else:
+		print("RESULT: FAIL - ", failures, " multi-shape index assertion(s) failed")
+	quit(1 if failures > 0 else 0)
+
+
+func _add_box(owner: CollisionObject3D, position: Vector3, size: Vector3, disabled: bool) -> void:
+	var collision: CollisionShape3D = CollisionShape3D.new()
+	var box: BoxShape3D = BoxShape3D.new()
+	box.size = size
+	collision.position = position
+	collision.shape = box
+	collision.disabled = disabled
+	owner.add_child(collision)
+
+
+func _add_sphere(owner: CollisionObject3D, position: Vector3, disabled: bool) -> void:
+	var collision: CollisionShape3D = CollisionShape3D.new()
+	var sphere: SphereShape3D = SphereShape3D.new()
+	sphere.radius = 0.5
+	collision.position = position
+	collision.shape = sphere
+	collision.disabled = disabled
+	owner.add_child(collision)
+
+
+func _find_rid(hits: Array[Dictionary], collider_rid: RID) -> Dictionary:
+	for hit in hits:
+		if hit.get("rid") == collider_rid:
+			return hit
+	return {}
+
+
+func _find_contact(state: PhysicsDirectBodyState3D, collider_rid: RID) -> int:
+	for index in state.get_contact_count():
+		if state.get_contact_collider(index) == collider_rid:
+			return index
+	return -1
+
+
+func _check(condition: bool, message: String) -> void:
+	if condition:
+		print("PASS: ", message)
+	else:
+		failures += 1
+		push_error("FAIL: " + message)


### PR DESCRIPTION
## Summary

- Map each live Box3D shape ID back to its stable Godot shape index.
- Report the correct shape index from direct-space queries, body contacts, and motion results.
- Add a focused regression using disabled shape 0 and active shape 1, and remove the documented limitation.

## Why

Multi-shape collision results currently fall back to shape index 0, so game logic cannot tell which shape was actually hit. This keeps Godot's shape indexing intact across the Box3D boundary.

## Validation

- `GODOT_BIN=/usr/local/bin/godot scripts/run_headless_tests.sh` (20/20 passed on macOS)
