### PR TITLE
Honor body and default damping modes

### DIFF
--- a/src/objects/box3d_body_impl_3d.hpp
+++ b/src/objects/box3d_body_impl_3d.hpp
@@ -33,6 +33,7 @@ struct Box3DContactPoint3D {
 class Box3DBodyImpl3D final : public Box3DShapedObjectImpl3D {
 public:
 	using BodyMode = PhysicsServer3D::BodyMode;
+	using BodyDampMode = PhysicsServer3D::BodyDampMode;
 
 	~Box3DBodyImpl3D() override;
 
@@ -66,6 +67,10 @@ public:
 
 	void set_linear_damping(real_t p_damping);
 
+	BodyDampMode get_linear_damp_mode() const { return linear_damp_mode; }
+
+	void set_linear_damp_mode(BodyDampMode p_mode) { linear_damp_mode = p_mode; }
+
 	real_t get_bounce() const { return bounce; }
 
 	void set_bounce(real_t p_bounce) { bounce = p_bounce; }
@@ -77,6 +82,10 @@ public:
 	real_t get_angular_damping() const { return angular_damping; }
 
 	void set_angular_damping(real_t p_damping);
+
+	BodyDampMode get_angular_damp_mode() const { return angular_damp_mode; }
+
+	void set_angular_damp_mode(BodyDampMode p_mode) { angular_damp_mode = p_mode; }
 
 	real_t get_gravity_scale() const { return gravity_scale; }
 
@@ -203,6 +212,8 @@ private:
 
 	real_t linear_damping = 0.0;
 	real_t angular_damping = 0.0;
+	BodyDampMode linear_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
+	BodyDampMode angular_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
 	real_t bounce = 0.0;
 	real_t friction = 1.0;
 	real_t gravity_scale = 1.0;

--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -605,9 +605,10 @@ void Box3DPhysicsServer3D::_body_set_param(const RID& p_body, PhysicsServer3D::B
 			body->set_gravity_scale(p_value);
 			break;
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE:
+			body->set_linear_damp_mode((PhysicsServer3D::BodyDampMode)(int)p_value);
+			break;
 		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE:
-			// Box3D always applies damping as a simple replace mode; COMBINE mode has no
-			// direct equivalent and is treated the same as REPLACE.
+			body->set_angular_damp_mode((PhysicsServer3D::BodyDampMode)(int)p_value);
 			break;
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP:
 			body->set_linear_damping(p_value);
@@ -637,8 +638,9 @@ Variant Box3DPhysicsServer3D::_body_get_param(const RID& p_body, PhysicsServer3D
 		case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE:
 			return body->get_gravity_scale();
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE:
+			return body->get_linear_damp_mode();
 		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP_MODE:
-			return PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
+			return body->get_angular_damp_mode();
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP:
 			return body->get_linear_damping();
 		case PhysicsServer3D::BODY_PARAM_ANGULAR_DAMP:

--- a/src/spaces/box3d_space_3d.cpp
+++ b/src/spaces/box3d_space_3d.cpp
@@ -114,8 +114,6 @@ struct AreaPriorityComparator {
 
 Box3DSpace3D::AreaOverrides Box3DSpace3D::compute_area_overrides(Box3DBodyImpl3D* p_body) const {
 	AreaOverrides result;
-	result.linear_damp = p_body->get_linear_damping();
-	result.angular_damp = p_body->get_angular_damping();
 
 	LocalVector<Box3DAreaImpl3D*> overlapping;
 	for (Box3DAreaImpl3D* area : areas) {
@@ -127,9 +125,6 @@ Box3DSpace3D::AreaOverrides Box3DSpace3D::compute_area_overrides(Box3DBodyImpl3D
 		if (area->get_overlaps().has(p_body)) {
 			overlapping.push_back(area);
 		}
-	}
-	if (overlapping.is_empty()) {
-		return result;
 	}
 	overlapping.sort_custom<AreaPriorityComparator>();
 
@@ -210,6 +205,24 @@ Box3DSpace3D::AreaOverrides Box3DSpace3D::compute_area_overrides(Box3DBodyImpl3D
 					break;
 			}
 		}
+	}
+
+	if (!linear_done && default_area != nullptr) {
+		result.linear_damp += default_area->get_linear_damp();
+	}
+	if (!angular_done && default_area != nullptr) {
+		result.angular_damp += default_area->get_angular_damp();
+	}
+
+	if (p_body->get_linear_damp_mode() == PhysicsServer3D::BODY_DAMP_MODE_REPLACE) {
+		result.linear_damp = p_body->get_linear_damping();
+	} else {
+		result.linear_damp += p_body->get_linear_damping();
+	}
+	if (p_body->get_angular_damp_mode() == PhysicsServer3D::BODY_DAMP_MODE_REPLACE) {
+		result.angular_damp = p_body->get_angular_damping();
+	} else {
+		result.angular_damp += p_body->get_angular_damping();
 	}
 
 	return result;

--- a/test_project/tests/body_damping_mode_test.gd
+++ b/test_project/tests/body_damping_mode_test.gd
@@ -1,0 +1,122 @@
+extends SceneTree
+
+class DampingProbe:
+	extends RigidBody3D
+
+	var sample_count: int = 0
+	var total_linear_damp: float = 0.0
+	var total_angular_damp: float = 0.0
+
+	func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:
+		sample_count += 1
+		total_linear_damp = state.get_total_linear_damp()
+		total_angular_damp = state.get_total_angular_damp()
+
+
+var failures: int = 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var body: DampingProbe = _make_probe()
+	body.linear_damp_mode = RigidBody3D.DAMP_MODE_COMBINE
+	body.angular_damp_mode = RigidBody3D.DAMP_MODE_COMBINE
+	body.linear_damp = 2.0
+	body.angular_damp = 3.0
+
+	for frame in 4:
+		await physics_frame
+
+	var default_linear: float = ProjectSettings.get_setting("physics/3d/default_linear_damp", 0.1)
+	var default_angular: float = ProjectSettings.get_setting("physics/3d/default_angular_damp", 0.1)
+	_check(body.sample_count > 0, "direct body state samples damping")
+	_check(
+		_is_close(body.total_linear_damp, default_linear + 2.0)
+				and _is_close(body.total_angular_damp, default_angular + 3.0),
+		"COMBINE body damping includes the default area",
+	)
+
+	var area: Area3D = _make_area()
+	area.linear_damp_space_override = Area3D.SPACE_OVERRIDE_COMBINE
+	area.angular_damp_space_override = Area3D.SPACE_OVERRIDE_COMBINE
+	area.linear_damp = 5.0
+	area.angular_damp = 7.0
+	for frame in 4:
+		await physics_frame
+	_check(
+		_is_close(body.total_linear_damp, default_linear + 7.0)
+				and _is_close(body.total_angular_damp, default_angular + 10.0),
+		"COMBINE body damping includes Area3D and default damping",
+	)
+
+	body.linear_damp_mode = RigidBody3D.DAMP_MODE_REPLACE
+	body.angular_damp_mode = RigidBody3D.DAMP_MODE_REPLACE
+	for frame in 2:
+		await physics_frame
+	_check(
+		_is_close(body.total_linear_damp, 2.0) and _is_close(body.total_angular_damp, 3.0),
+		"REPLACE body damping excludes Area3D and default damping",
+	)
+	_check(
+		PhysicsServer3D.body_get_param(body.get_rid(), PhysicsServer3D.BODY_PARAM_LINEAR_DAMP_MODE)
+				== PhysicsServer3D.BODY_DAMP_MODE_REPLACE
+				and PhysicsServer3D.body_get_param(body.get_rid(), PhysicsServer3D.BODY_PARAM_ANGULAR_DAMP_MODE)
+				== PhysicsServer3D.BODY_DAMP_MODE_REPLACE,
+		"body damping modes round-trip through PhysicsServer3D",
+	)
+
+	body.linear_damp_mode = RigidBody3D.DAMP_MODE_COMBINE
+	body.angular_damp_mode = RigidBody3D.DAMP_MODE_COMBINE
+	area.linear_damp_space_override = Area3D.SPACE_OVERRIDE_COMBINE_REPLACE
+	area.angular_damp_space_override = Area3D.SPACE_OVERRIDE_COMBINE_REPLACE
+	for frame in 2:
+		await physics_frame
+	_check(
+		_is_close(body.total_linear_damp, 7.0) and _is_close(body.total_angular_damp, 10.0),
+		"COMBINE_REPLACE Area3D damping excludes the default area",
+	)
+
+	if failures == 0:
+		print("RESULT: PASS - body and default damping modes are honored")
+	else:
+		print("RESULT: FAIL - ", failures, " damping mode assertion(s) failed")
+	quit(1 if failures > 0 else 0)
+
+
+func _make_probe() -> DampingProbe:
+	var body: DampingProbe = DampingProbe.new()
+	body.gravity_scale = 0.0
+	body.can_sleep = false
+	var collision: CollisionShape3D = CollisionShape3D.new()
+	var sphere: SphereShape3D = SphereShape3D.new()
+	sphere.radius = 0.5
+	collision.shape = sphere
+	body.add_child(collision)
+	root.add_child(body)
+	return body
+
+
+func _make_area() -> Area3D:
+	var area: Area3D = Area3D.new()
+	var collision: CollisionShape3D = CollisionShape3D.new()
+	var box: BoxShape3D = BoxShape3D.new()
+	box.size = Vector3(10, 10, 10)
+	collision.shape = box
+	area.add_child(collision)
+	root.add_child(area)
+	return area
+
+
+func _is_close(actual: float, expected: float) -> bool:
+	return absf(actual - expected) < 0.001
+
+
+func _check(condition: bool, message: String) -> void:
+	if condition:
+		print("PASS: ", message)
+	else:
+		failures += 1
+		push_error("FAIL: " + message)


### PR DESCRIPTION
## Summary

- Store and round-trip each body's linear and angular damping modes.
- Include default-area damping for `COMBINE`, while preserving Area3D priority and replacement semantics.
- Let body `REPLACE` mode override both Area3D and default damping.
- Add a focused direct-body-state regression for the resulting totals.

## Why

The backend currently ignores body damping modes and omits project default damping. It also needs to stop adding the default area after an Area3D `COMBINE_REPLACE` or `REPLACE` override.

## Validation

- Independent C++ syntax build against current upstream `main`
- Focused backend activation and damping-mode tests passed on macOS
- Full headless physics suite passed (21/21) in an integration validation with the independent multi-shape patch
