### PR TITLE
Ship a self-contained Windows release DLL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,28 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
+      - name: Install Godot (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          GODOT_VERSION: 4.7-stable
+          GODOT_ARCHIVE: Godot_v4.7-stable_win64.exe.zip
+        run: |
+          mkdir -p "$RUNNER_TEMP/godot"
+          curl -L --fail --retry 3 \
+            -o "$RUNNER_TEMP/${GODOT_ARCHIVE}" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/${GODOT_ARCHIVE}"
+          unzip -o "$RUNNER_TEMP/${GODOT_ARCHIVE}" -d "$RUNNER_TEMP/godot"
+
+      - name: Run headless tests (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          GODOT_BIN: ${{ runner.temp }}/godot/Godot_v4.7-stable_win64.exe
+          TEST_SUMMARY: ${{ runner.temp }}/test-summary.md
+          BUILD_DIR: ${{ github.workspace }}/build
+        run: scripts/run_headless_tests.sh
+
       - name: Install Godot (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -68,7 +90,7 @@ jobs:
         run: scripts/run_headless_tests.sh
 
       - name: Publish test summary
-        if: runner.os == 'Linux' && always()
+        if: (runner.os == 'Linux' || runner.os == 'Windows') && always()
         shell: bash
         run: |
           if [[ -f "$RUNNER_TEMP/test-summary.md" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	target_compile_options(godot-box3d PRIVATE -Wall)
 endif()
 
+# GitHub's Windows runner and the documented Ninja build select MinGW. Its default shared
+# runtime dependencies are not shipped with the addon, so a release DLL otherwise fails to
+# load with Windows error 126 on a clean Godot installation.
+if(MINGW)
+	target_link_options(godot-box3d PRIVATE -static-libgcc -static-libstdc++ -static)
+endif()
+
 # The .gdextension expects "godot-box3d.dll" on Windows but "libgodot-box3d.so/.dylib"
 # elsewhere, so the prefix is per-platform rather than a blanket "lib".
 if(WIN32)

--- a/scripts/run_headless_tests.sh
+++ b/scripts/run_headless_tests.sh
@@ -17,6 +17,9 @@ case "$(uname -s)" in
 	Darwin)
 		extension_filename="libgodot-box3d.dylib"
 		;;
+	MINGW*|MSYS*|CYGWIN*)
+		extension_filename="godot-box3d.dll"
+		;;
 	*)
 		extension_filename="libgodot-box3d.so"
 		;;
@@ -36,7 +39,10 @@ if [[ ! -f "$extension_library" ]]; then
 fi
 
 mkdir -p "$test_addon_bin" "$godot_metadata_dir"
-ln -sf "$extension_library" "$test_addon_bin/$extension_filename"
+# Windows runners do not grant the symlink privilege by default. A real copy also matches
+# how users install the release archive that this test is intended to validate.
+rm -f "$test_addon_bin/$extension_filename"
+cp -f "$extension_library" "$test_addon_bin/$extension_filename"
 
 # Running a script directly does not scan the project for GDExtensions, so register Box3D by
 # hand. Only Box3D: the tests never exercise another backend, and a second GDExtension built


### PR DESCRIPTION
## Summary

- statically link the MinGW runtime dependencies into the Windows GDExtension
- teach the headless runner to locate and stage the Windows DLL
- install Godot 4.7 and run the physics regression suite on Windows CI

This keeps the release DLL self-contained instead of requiring users to install matching MinGW runtime DLLs beside their project.

Closes #20

## Validation

- the same static-link and DLL-staging path passed the complete headless suite on `windows-latest`
- `actionlint .github/workflows/build.yml`
- workflow YAML parse and `bash -n scripts/run_headless_tests.sh`
- `git diff --check`