### PR TITLE
Build universal macOS release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,42 @@ jobs:
         run: choco install ninja
 
       - name: Configure
+        if: runner.os != 'macOS'
         run: cmake -B build -G "${{ matrix.cmake-generator }}"
+
+      - name: Configure universal macOS build
+        if: runner.os == 'macOS'
+        run: >-
+          cmake -B build -G "${{ matrix.cmake-generator }}"
+          -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
       - name: Build
         run: cmake --build build --parallel
+
+      - name: Verify universal macOS binary
+        if: runner.os == 'macOS'
+        run: lipo bin/libgodot-box3d.dylib -verify_arch arm64 x86_64
+
+      - name: Install Godot (macOS)
+        if: runner.os == 'macOS'
+        env:
+          GODOT_VERSION: 4.7-stable
+          GODOT_ARCHIVE: Godot_v4.7-stable_macos.universal.zip
+        run: |
+          mkdir -p "$RUNNER_TEMP/godot"
+          curl -L --fail --retry 3 \
+            -o "$RUNNER_TEMP/${GODOT_ARCHIVE}" \
+            "https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/${GODOT_ARCHIVE}"
+          unzip -o "$RUNNER_TEMP/${GODOT_ARCHIVE}" -d "$RUNNER_TEMP/godot"
+          chmod +x "$RUNNER_TEMP/godot/Godot.app/Contents/MacOS/Godot"
+
+      - name: Run headless tests (macOS)
+        if: runner.os == 'macOS'
+        env:
+          GODOT_BIN: ${{ runner.temp }}/godot/Godot.app/Contents/MacOS/Godot
+          TEST_SUMMARY: ${{ runner.temp }}/test-summary.md
+          BUILD_DIR: ${{ github.workspace }}/build
+        run: scripts/run_headless_tests.sh
 
       - name: Install Godot (Linux)
         if: runner.os == 'Linux'
@@ -68,7 +100,7 @@ jobs:
         run: scripts/run_headless_tests.sh
 
       - name: Publish test summary
-        if: runner.os == 'Linux' && always()
+        if: (runner.os == 'Linux' || runner.os == 'macOS') && always()
         shell: bash
         run: |
           if [[ -f "$RUNNER_TEMP/test-summary.md" ]]; then

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ New tech is cool and Godot is great. That's most of it. This is my first time do
 | Joints | 3 (pin, hinge, slider) | 8 (adds ball, fixed, motor, wheel, parallel, distance) |
 | Vehicles | `VehicleBody3D` (raycast) | `Box3DWheelJoint` (real constraint) |
 | Heightfields | Yes | No |
-| Platforms | Linux, Windows (macOS arm64, untested) | + Android, web |
+| Platforms | Linux, Windows (macOS universal, experimental) | + Android, web |
 | Box3D-only features | Not reachable | Explosions, gyroscopic torque, solver profiling, async stepping |
 
 box3d-godot exposes more of Box3D. This project keeps your project working.
@@ -61,7 +61,7 @@ Use this if you have an existing project or want stock nodes and addons to work.
 - `SoftBody3D`
 - Per-shape indices in query and contact results (multi-shape bodies always report shape 0)
 - Solver profiling
-- macOS support: universal binaries and notarization (arm64 builds compile but are untested)
+- macOS support: notarization and runtime validation of both architecture slices
 - More platforms and architectures (currently Linux and Windows)
 - Performance benchmarking and tuning
 
@@ -131,7 +131,7 @@ Then set **Project Settings → Physics → 3D → Physics Engine** to `Box3D Ph
 
 The solver is multithreaded. By default it uses one worker per physical core (efficiency cores and hyperthreads are excluded, since they slow the solver's synchronised stages down). To override it, set `physics/box3d/worker_count` (visible with Advanced Settings on) to an explicit count; `0` means auto. This also needs a restart, and simulation results are identical at any worker count.
 
-> **macOS is a work in progress.** Builds are Apple Silicon (arm64) only and are not notarized, so Intel Macs cannot load the library and Gatekeeper will need convincing on any Mac. Linux and Windows are the tested platforms. macOS is untested beyond compiling, so treat it as unsupported for now.
+> **macOS is a work in progress.** Release artifacts contain a universal arm64/x86_64 library and run the headless physics suite on the GitHub-hosted macOS architecture. The library is not notarized, and the other architecture slice is compile-checked only, so Gatekeeper may block it and macOS should still be treated as experimental.
 
 ## Building
 

--- a/cmake/GodotBox3DExternalGodotCpp.cmake
+++ b/cmake/GodotBox3DExternalGodotCpp.cmake
@@ -55,7 +55,17 @@ if(CMAKE_TOOLCHAIN_FILE)
 	list(APPEND GODOT_CPP_TOOLCHAIN_ARGS "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
 endif()
 
+# Keep the external godot-cpp archive architecture-compatible with this extension. Without
+# forwarding this value, a universal extension configure still produces a host-only godot-cpp
+# archive and fails when the second architecture is linked.
+set(GODOT_CPP_PLATFORM_ARGS "")
+if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+	string(REPLACE ";" "|" GODOT_CPP_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+	list(APPEND GODOT_CPP_PLATFORM_ARGS "-DCMAKE_OSX_ARCHITECTURES=${GODOT_CPP_OSX_ARCHITECTURES}")
+endif()
+
 ExternalProject_Add(godot-cpp-external
+	LIST_SEPARATOR |
 	PREFIX "${GODOT_CPP_PREFIX}"
 	GIT_REPOSITORY "${GODOT_CPP_GIT_REPOSITORY}"
 	GIT_TAG "${GODOT_CPP_GIT_TAG}"
@@ -68,6 +78,7 @@ ExternalProject_Add(godot-cpp-external
 		-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
 		-DCMAKE_POSITION_INDEPENDENT_CODE=ON
 		${GODOT_CPP_TOOLCHAIN_ARGS}
+		${GODOT_CPP_PLATFORM_ARGS}
 		${GODOT_CPP_BUILD_TYPE_ARG}
 	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${GODOT_CPP_BUILD_CONFIG_ARG} --target godot-cpp
 	INSTALL_COMMAND ""

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -17,7 +17,7 @@ Different projects solving different problems, so this is a comparison rather th
 | Joints | 3 (pin, hinge, slider) | 8 (adds ball, fixed, motor, wheel, parallel, distance) |
 | Vehicles | `VehicleBody3D` (raycast) | `Box3DWheelJoint` (real constraint) |
 | Heightfields | Yes | No |
-| Platforms | Linux, Windows (macOS arm64, untested) | + Android, web |
+| Platforms | Linux, Windows (macOS universal, experimental) | + Android, web |
 | Box3D-only features | Not reachable | Explosions, gyroscopic torque, solver profiling, async stepping |
 
 ## The trade

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Box3D is worth trying because of where it came from. [Erin Catto](https://x.com/
 - `SoftBody3D`
 - Per-shape indices in query and contact results (multi-shape bodies always report shape 0)
 - Solver profiling
-- macOS universal binaries and notarization
+- macOS notarization and runtime validation of both architecture slices
 
 ## Benchmark
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,10 +38,9 @@ Worker count changes also need a restart, and simulation results are identical a
 |---|---|
 | Linux x86_64 | Tested |
 | Windows x86_64 | Tested |
-| macOS arm64 | Compiles, untested |
-| macOS x86_64 | Not built |
+| macOS arm64/x86_64 | Universal binary; CI runtime-tests the hosted runner architecture |
 
-macOS is a work in progress. Builds are Apple Silicon only and are not notarized, so Intel Macs cannot load the library and Gatekeeper will need convincing on any Mac.
+macOS is a work in progress. Release artifacts contain a universal arm64/x86_64 library and CI runs the headless physics suite on the hosted runner architecture. The other slice is compile-checked only, and the library is not notarized, so Gatekeeper may block it.
 
 ## Verifying it loaded
 

--- a/scripts/run_headless_tests.sh
+++ b/scripts/run_headless_tests.sh
@@ -63,12 +63,17 @@ write_summary() {
 		fi
 		printf '| Result | Test |\n|---|---|\n'
 		local test_script
-		for test_script in "${failed_tests[@]}"; do
-			printf '| FAIL | `%s` |\n' "$test_script"
-		done
-		for test_script in "${passed_tests[@]}"; do
-			printf '| pass | `%s` |\n' "$test_script"
-		done
+		# Bash 3.2 on the macOS runner treats an empty array expansion as unset with `set -u`.
+		if (( ${#failed_tests[@]} > 0 )); then
+			for test_script in "${failed_tests[@]}"; do
+				printf '| FAIL | `%s` |\n' "$test_script"
+			done
+		fi
+		if (( ${#passed_tests[@]} > 0 )); then
+			for test_script in "${passed_tests[@]}"; do
+				printf '| pass | `%s` |\n' "$test_script"
+			done
+		fi
 	} > "$TEST_SUMMARY"
 }
 


### PR DESCRIPTION
## Summary

- forward `CMAKE_OSX_ARCHITECTURES` into the external godot-cpp build
- build and verify a universal `arm64`/`x86_64` macOS GDExtension in CI
- run the headless physics suite with official Godot 4.7 on the hosted macOS architecture
- make the optional test-summary writer safe on the runner Bash 3.2
- document the remaining notarization and second-slice runtime-validation limits

This lets one release artifact load on both Apple Silicon and Intel Macs while keeping the current experimental support status explicit.

## Validation

- full universal CMake build completed locally
- `lipo -verify_arch arm64 x86_64 bin/libgodot-box3d.dylib`
- all 19 upstream headless tests and the generated summary passed with official Godot 4.7
- first hosted run passed Linux and Windows; macOS passed all physics tests and exposed the now-fixed Bash 3.2 summary issue
- `actionlint .github/workflows/build.yml`, workflow YAML parse, and `git diff --check`