### PR TITLE
Recover CharacterBody motion before shape casts

### DIFF
--- a/src/misc/box3d_shape_proxy.cpp
+++ b/src/misc/box3d_shape_proxy.cpp
@@ -11,10 +11,11 @@
 
 #include <box3d/collision.h>
 
-Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Transform3D& p_transform) {
+Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Transform3D& p_transform, double p_margin) {
 	if (p_shape == nullptr) {
 		return;
 	}
+	const float margin = MAX(0.0f, (float)p_margin);
 
 	switch (p_shape->get_type()) {
 		case PhysicsServer3D::SHAPE_SPHERE: {
@@ -23,7 +24,7 @@ Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Tran
 			points[0] = godot_to_b3(p_transform.origin);
 			proxy.points = points.ptr();
 			proxy.count = 1;
-			proxy.radius = (float)sphere->get_radius();
+			proxy.radius = (float)sphere->get_radius() + margin;
 			supported = true;
 			break;
 		}
@@ -37,7 +38,7 @@ Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Tran
 			points[1] = godot_to_b3(p_transform.xform(Vector3(0, -half_seg, 0)));
 			proxy.points = points.ptr();
 			proxy.count = 2;
-			proxy.radius = radius;
+			proxy.radius = radius + margin;
 			supported = true;
 			break;
 		}
@@ -57,7 +58,7 @@ Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Tran
 			}
 			proxy.points = points.ptr();
 			proxy.count = 8;
-			proxy.radius = 0.0f;
+			proxy.radius = margin;
 			supported = true;
 			break;
 		}
@@ -78,7 +79,7 @@ Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Tran
 			}
 			proxy.points = points.ptr();
 			proxy.count = 2 * sides;
-			proxy.radius = 0.0f;
+			proxy.radius = margin;
 			supported = true;
 			break;
 		}
@@ -100,7 +101,7 @@ Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Tran
 			}
 			proxy.points = points.ptr();
 			proxy.count = count;
-			proxy.radius = 0.0f;
+			proxy.radius = margin;
 			supported = true;
 			break;
 		}

--- a/src/misc/box3d_shape_proxy.hpp
+++ b/src/misc/box3d_shape_proxy.hpp
@@ -17,7 +17,7 @@ class Box3DShapeImpl3D;
 // should fall back to a different strategy (e.g. AABB overlap) for those shape types.
 class Box3DShapeProxy3D {
 public:
-	Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Transform3D& p_transform);
+	Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Transform3D& p_transform, double p_margin = 0.0);
 
 	bool is_supported() const { return supported; }
 

--- a/src/spaces/box3d_physics_direct_space_state_3d.cpp
+++ b/src/spaces/box3d_physics_direct_space_state_3d.cpp
@@ -12,6 +12,8 @@
 
 #include <box3d/box3d.h>
 
+#include <godot_cpp/templates/local_vector.hpp>
+
 namespace {
 
 struct OverlapContext {
@@ -138,6 +140,213 @@ float cast_result_fcn(b3ShapeId p_shape_id, b3Pos p_point, b3Vec3 p_normal, floa
 	ctx->normal = p_normal;
 	ctx->fraction = p_fraction;
 	return p_fraction;
+}
+
+int32_t find_shape_index(const Box3DShapedObjectImpl3D& p_object, b3ShapeId p_shape_id) {
+	for (int32_t i = 0; i < p_object.get_shape_count(); i++) {
+		if (p_object.has_shape_id(i) && B3_ID_EQUALS(p_object.get_shape_id(i), p_shape_id)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+struct MotionCollisionData {
+	Box3DShapedObjectImpl3D* object = nullptr;
+	Vector3 position;
+	Vector3 normal;
+	real_t depth = 0.0;
+	float fraction = 1.0f;
+	int32_t local_shape = -1;
+	int32_t collider_shape = -1;
+};
+
+void append_motion_collision(LocalVector<MotionCollisionData>& r_collisions, const MotionCollisionData& p_collision) {
+	if (p_collision.object == nullptr || p_collision.normal.length_squared() < CMP_EPSILON) {
+		return;
+	}
+	for (MotionCollisionData& existing : r_collisions) {
+		if (existing.object == p_collision.object && existing.local_shape == p_collision.local_shape &&
+				existing.collider_shape == p_collision.collider_shape) {
+			if (p_collision.depth > existing.depth || p_collision.fraction < existing.fraction) {
+				existing = p_collision;
+			}
+			return;
+		}
+	}
+	r_collisions.push_back(p_collision);
+}
+
+struct MotionCastContext {
+	const Box3DQueryFilter3D* filter = nullptr;
+	LocalVector<MotionCollisionData>* collisions = nullptr;
+	bool has_hit = false;
+	Box3DShapedObjectImpl3D* object = nullptr;
+	b3Pos point{};
+	b3Vec3 normal{};
+	float fraction = 1.0f;
+	int32_t local_shape = -1;
+	int32_t collider_shape = -1;
+};
+
+float motion_cast_result_fcn(
+		b3ShapeId p_shape_id,
+		b3Pos p_point,
+		b3Vec3 p_normal,
+		float p_fraction,
+		uint64_t,
+		int,
+		int,
+		void* p_context) {
+	auto* ctx = static_cast<MotionCastContext*>(p_context);
+
+	const b3BodyId body_id = b3Shape_GetBody(p_shape_id);
+	Box3DShapedObjectImpl3D* object = nullptr;
+	if (!should_report(b3Body_GetUserData(body_id), *ctx->filter, object)) {
+		return -1.0f;
+	}
+
+	// Box3D can report a zero normal for a cast that begins overlapped. Godot requires
+	// every motion collision normal to be normalized, so recovery handles that case.
+	if (p_fraction <= CMP_EPSILON && b3LengthSquared(p_normal) < 0.25f) {
+		return -1.0f;
+	}
+
+	const int32_t collider_shape = find_shape_index(*object, p_shape_id);
+	MotionCollisionData collision;
+	collision.object = object;
+	collision.position = b3_to_godot(p_point);
+	collision.normal = b3_to_godot(p_normal);
+	collision.fraction = p_fraction;
+	collision.local_shape = ctx->local_shape;
+	collision.collider_shape = collider_shape;
+	append_motion_collision(*ctx->collisions, collision);
+
+	if (ctx->has_hit && p_fraction >= ctx->fraction) {
+		return ctx->fraction;
+	}
+	ctx->has_hit = true;
+	ctx->object = object;
+	ctx->point = p_point;
+	ctx->normal = p_normal;
+	ctx->fraction = p_fraction;
+	ctx->collider_shape = collider_shape;
+	return p_fraction;
+}
+
+b3AABB proxy_aabb(const b3ShapeProxy& p_proxy) {
+	if (p_proxy.points == nullptr || p_proxy.count <= 0) {
+		return b3AABB{b3Vec3_zero, b3Vec3_zero};
+	}
+	b3Vec3 lower = p_proxy.points[0];
+	b3Vec3 upper = p_proxy.points[0];
+	for (int32_t i = 1; i < p_proxy.count; i++) {
+		lower = b3Min(lower, p_proxy.points[i]);
+		upper = b3Max(upper, p_proxy.points[i]);
+	}
+	const b3Vec3 radius{p_proxy.radius, p_proxy.radius, p_proxy.radius};
+	return b3AABB{b3Sub(lower, radius), b3Add(upper, radius)};
+}
+
+// Box3D stores every shape AABB with its speculative contact distance on each side.
+// Remove that known inflation so recovery does not make characters hover.
+b3AABB exact_shape_aabb(b3ShapeId p_shape_id) {
+	b3AABB aabb = b3Shape_GetAABB(p_shape_id);
+	const b3Vec3 inflation{B3_SPECULATIVE_DISTANCE, B3_SPECULATIVE_DISTANCE, B3_SPECULATIVE_DISTANCE};
+	aabb.lowerBound = b3Add(aabb.lowerBound, inflation);
+	aabb.upperBound = b3Sub(aabb.upperBound, inflation);
+	return aabb;
+}
+
+struct RecoveryContext {
+	const Box3DQueryFilter3D* filter = nullptr;
+	b3AABB query_aabb{};
+	Vector3 preferred_motion;
+	Vector3* accumulated_push = nullptr;
+	int32_t* push_count = nullptr;
+	int32_t local_shape = -1;
+	LocalVector<MotionCollisionData>* collisions = nullptr;
+};
+
+bool recovery_result_fcn(b3ShapeId p_shape_id, void* p_context) {
+	auto* ctx = static_cast<RecoveryContext*>(p_context);
+	const b3BodyId body_id = b3Shape_GetBody(p_shape_id);
+	Box3DShapedObjectImpl3D* object = nullptr;
+	if (!should_report(b3Body_GetUserData(body_id), *ctx->filter, object)) {
+		return true;
+	}
+
+	const b3AABB target_aabb = exact_shape_aabb(p_shape_id);
+	const float depths[3] = {
+		MIN(ctx->query_aabb.upperBound.x, target_aabb.upperBound.x) -
+				MAX(ctx->query_aabb.lowerBound.x, target_aabb.lowerBound.x),
+		MIN(ctx->query_aabb.upperBound.y, target_aabb.upperBound.y) -
+				MAX(ctx->query_aabb.lowerBound.y, target_aabb.lowerBound.y),
+		MIN(ctx->query_aabb.upperBound.z, target_aabb.upperBound.z) -
+				MAX(ctx->query_aabb.lowerBound.z, target_aabb.lowerBound.z),
+	};
+	if (depths[0] <= CMP_EPSILON || depths[1] <= CMP_EPSILON || depths[2] <= CMP_EPSILON) {
+		return true;
+	}
+
+	int32_t axis = 0;
+	if (depths[1] < depths[axis]) {
+		axis = 1;
+	}
+	if (depths[2] < depths[axis]) {
+		axis = 2;
+	}
+
+	const b3Vec3 query_center = b3MulSV(0.5f, b3Add(ctx->query_aabb.lowerBound, ctx->query_aabb.upperBound));
+	const b3Vec3 target_center = b3MulSV(0.5f, b3Add(target_aabb.lowerBound, target_aabb.upperBound));
+	const float query_axis = axis == 0 ? query_center.x : axis == 1 ? query_center.y : query_center.z;
+	const float target_axis = axis == 0 ? target_center.x : axis == 1 ? target_center.y : target_center.z;
+	const real_t motion_axis = ctx->preferred_motion[axis];
+	const float direction = Math::is_equal_approx(query_axis, target_axis) ?
+			(motion_axis > 0.0 ? -1.0f : 1.0f) :
+			(query_axis > target_axis ? 1.0f : -1.0f);
+
+	Vector3 normal;
+	normal[axis] = direction;
+	const real_t depth = depths[axis];
+	const Vector3 push = normal * (depth + B3_LINEAR_SLOP);
+	const real_t existing_push = (*ctx->accumulated_push)[axis];
+	const bool candidate_is_deeper = Math::abs(push[axis]) > Math::abs(existing_push);
+	const bool candidate_better_opposes_motion =
+			Math::is_equal_approx(Math::abs(push[axis]), Math::abs(existing_push)) &&
+			push[axis] * motion_axis < existing_push * motion_axis;
+	if (candidate_is_deeper || candidate_better_opposes_motion) {
+		(*ctx->accumulated_push)[axis] = push[axis];
+	}
+	(*ctx->push_count)++;
+
+	MotionCollisionData collision;
+	collision.object = object;
+	collision.position = b3_to_godot(b3Shape_GetClosestPoint(p_shape_id, query_center));
+	collision.normal = normal;
+	collision.depth = depth;
+	collision.local_shape = ctx->local_shape;
+	collision.collider_shape = find_shape_index(*object, p_shape_id);
+	append_motion_collision(*ctx->collisions, collision);
+	return true;
+}
+
+void fill_motion_collision(const MotionCollisionData& p_source, PhysicsServer3DExtensionMotionCollision& r_target) {
+	r_target.position = p_source.position;
+	r_target.normal = p_source.normal.normalized();
+	r_target.depth = p_source.depth;
+	r_target.local_shape = p_source.local_shape;
+	r_target.collider = p_source.object->get_rid();
+	r_target.collider_id = p_source.object->get_instance_id();
+	r_target.collider_shape = p_source.collider_shape;
+
+	auto* body = dynamic_cast<Box3DBodyImpl3D*>(p_source.object);
+	if (body != nullptr) {
+		r_target.collider_angular_velocity = body->get_angular_velocity();
+		const Vector3 center_of_mass = body->get_transform().xform(body->get_center_of_mass());
+		r_target.collider_velocity =
+				body->get_linear_velocity() + body->get_angular_velocity().cross(p_source.position - center_of_mass);
+	}
 }
 
 } // namespace
@@ -402,6 +611,7 @@ bool Box3DPhysicsDirectSpaceState3D::test_body_motion(
 		bool p_recovery_as_collision,
 		PhysicsServer3DExtensionMotionResult* p_result) const {
 	ERR_FAIL_NULL_V(space, false);
+	ERR_FAIL_NULL_V(p_result, false);
 
 	p_result->travel = Vector3();
 	p_result->remainder = p_motion;
@@ -416,52 +626,167 @@ bool Box3DPhysicsDirectSpaceState3D::test_body_motion(
 		return false;
 	}
 
-	Box3DShapeImpl3D* first_shape = p_body.get_shape(0);
-	if (first_shape == nullptr) {
-		p_result->travel = p_motion;
-		p_result->remainder = Vector3();
-		return false;
-	}
-
 	Box3DQueryFilter3D filter;
 	filter.set_collision_mask(p_body.get_collision_mask());
 	filter.exclude.insert(p_body.get_rid());
+	if (auto* body = dynamic_cast<Box3DBodyImpl3D*>(&p_body)) {
+		for (const KeyValue<RID, Box3DFilterJointImpl3D*>& entry : body->get_collision_exceptions()) {
+			filter.exclude.insert(entry.key);
+		}
+	}
 
-	const Box3DShapeProxy3D shape_proxy(first_shape, p_transform * p_body.get_shape_transform(0));
-	if (!shape_proxy.is_supported()) {
+	const double margin = MAX(p_margin, 0.001);
+	Transform3D recovered_transform = p_transform;
+	LocalVector<MotionCollisionData> recovery_collisions;
+	bool found_supported_shape = false;
+	bool recovered = false;
+
+	// Resolve initial overlap before casting. This is required for CharacterBody3D,
+	// which normally begins each frame touching or slightly embedded in the floor.
+	for (int32_t attempt = 0; attempt < 4; attempt++) {
+		Vector3 accumulated_push;
+		int32_t push_count = 0;
+
+		for (int32_t i = 0; i < p_body.get_shape_count(); i++) {
+			if (p_body.is_shape_disabled(i)) {
+				continue;
+			}
+			Box3DShapeImpl3D* shape = p_body.get_shape(i);
+			if (shape == nullptr) {
+				continue;
+			}
+			const Box3DShapeProxy3D shape_proxy(shape, recovered_transform * p_body.get_shape_transform(i), margin);
+			if (!shape_proxy.is_supported()) {
+				continue;
+			}
+			found_supported_shape = true;
+
+			RecoveryContext context;
+			context.filter = &filter;
+			context.query_aabb = proxy_aabb(shape_proxy.get_proxy());
+			context.preferred_motion = p_motion;
+			context.accumulated_push = &accumulated_push;
+			context.push_count = &push_count;
+			context.local_shape = i;
+			context.collisions = &recovery_collisions;
+			b3World_OverlapShape(
+					space->get_world_id(),
+					b3Vec3_zero,
+					&shape_proxy.get_proxy(),
+					filter.filter,
+					recovery_result_fcn,
+					&context);
+		}
+
+		if (push_count == 0 || accumulated_push.length_squared() <= CMP_EPSILON) {
+			break;
+		}
+		recovered_transform.origin += accumulated_push;
+		recovered = true;
+	}
+
+	bool found_collision = false;
+	MotionCastContext best_context;
+	best_context.filter = &filter;
+	LocalVector<MotionCollisionData> cast_collisions;
+
+	for (int32_t i = 0; i < p_body.get_shape_count(); i++) {
+		if (p_body.is_shape_disabled(i)) {
+			continue;
+		}
+		Box3DShapeImpl3D* shape = p_body.get_shape(i);
+		if (shape == nullptr) {
+			continue;
+		}
+		const Box3DShapeProxy3D shape_proxy(shape, recovered_transform * p_body.get_shape_transform(i), margin);
+		if (!shape_proxy.is_supported()) {
+			continue;
+		}
+		found_supported_shape = true;
+		if (p_motion.is_zero_approx()) {
+			continue;
+		}
+
+		MotionCastContext context;
+		context.filter = &filter;
+		context.collisions = &cast_collisions;
+		context.local_shape = i;
+		b3World_CastShape(
+				space->get_world_id(),
+				b3Vec3_zero,
+				&shape_proxy.get_proxy(),
+				godot_to_b3(p_motion),
+				filter.filter,
+				motion_cast_result_fcn,
+				&context);
+		if (context.has_hit && (!found_collision || context.fraction < best_context.fraction)) {
+			best_context = context;
+			found_collision = true;
+		}
+	}
+
+	if (!found_supported_shape) {
 		p_result->travel = p_motion;
 		p_result->remainder = Vector3();
 		return false;
 	}
 
-	RayContext context;
-	context.filter = &filter;
+	const Vector3 recovery = recovered_transform.origin - p_transform.origin;
+	const float unsafe_fraction = found_collision ? best_context.fraction : 1.0f;
+	const float motion_length = (float)p_motion.length();
+	const float safe_backoff_fraction = found_collision && motion_length > CMP_EPSILON ?
+			MIN(1.0f, MAX((float)margin, B3_LINEAR_SLOP) / motion_length) :
+			0.0f;
+	const float safe_fraction = found_collision ? MAX(0.0f, unsafe_fraction - safe_backoff_fraction) : 1.0f;
+	p_result->travel = recovery + p_motion * safe_fraction;
+	p_result->remainder = p_motion * (1.0f - safe_fraction);
+	p_result->collision_safe_fraction = safe_fraction;
+	p_result->collision_unsafe_fraction = unsafe_fraction;
 
-	b3World_CastShape(space->get_world_id(), b3Vec3_zero, &shape_proxy.get_proxy(), godot_to_b3(p_motion), filter.filter, cast_result_fcn, &context);
-
-	if (!context.has_hit) {
-		p_result->travel = p_motion;
-		p_result->remainder = Vector3();
-		return false;
+	LocalVector<MotionCollisionData> reported_collisions;
+	if (found_collision && best_context.object != nullptr) {
+		MotionCollisionData collision;
+		collision.object = best_context.object;
+		collision.position = b3_to_godot(best_context.point);
+		collision.normal = b3_to_godot(best_context.normal);
+		collision.fraction = best_context.fraction;
+		collision.local_shape = best_context.local_shape;
+		collision.collider_shape = best_context.collider_shape;
+		append_motion_collision(reported_collisions, collision);
+	}
+	if (found_collision) {
+		for (const MotionCollisionData& collision : cast_collisions) {
+			if (collision.fraction <= unsafe_fraction + 0.001f) {
+				append_motion_collision(reported_collisions, collision);
+			}
+		}
+	}
+	if (recovered && p_recovery_as_collision) {
+		for (const MotionCollisionData& collision : recovery_collisions) {
+			append_motion_collision(reported_collisions, collision);
+		}
 	}
 
-	p_result->travel = p_motion * context.fraction;
-	p_result->remainder = p_motion * (1.0f - context.fraction);
-	p_result->collision_safe_fraction = context.fraction;
-	p_result->collision_unsafe_fraction = context.fraction;
-
-	const b3BodyId body_id = b3Shape_GetBody(context.shape_id);
-	auto* other = static_cast<Box3DShapedObjectImpl3D*>(b3Body_GetUserData(body_id));
-	if (other != nullptr && p_max_collisions > 0) {
-		PhysicsServer3DExtensionMotionCollision& collision = p_result->collisions[0];
-		collision.position = b3_to_godot(context.point);
-		collision.normal = b3_to_godot(context.normal);
-		collision.collider = other->get_rid();
-		collision.collider_id = other->get_instance_id();
-		collision.collider_shape = 0;
-		collision.depth = 0.0f;
-		p_result->collision_count = 1;
+	for (uint32_t i = 0; i < reported_collisions.size(); i++) {
+		uint32_t best = i;
+		for (uint32_t j = i + 1; j < reported_collisions.size(); j++) {
+			if (reported_collisions[j].depth > reported_collisions[best].depth ||
+					(Math::is_equal_approx(reported_collisions[j].depth, reported_collisions[best].depth) &&
+							reported_collisions[j].fraction < reported_collisions[best].fraction)) {
+				best = j;
+			}
+		}
+		if (best != i) {
+			SWAP(reported_collisions[i], reported_collisions[best]);
+		}
 	}
 
-	return true;
+	const int32_t collision_limit = MAX(0, MIN(MIN(p_max_collisions, 32), (int32_t)reported_collisions.size()));
+	for (int32_t i = 0; i < collision_limit; i++) {
+		fill_motion_collision(reported_collisions[i], p_result->collisions[i]);
+		p_result->collision_depth = MAX(p_result->collision_depth, reported_collisions[i].depth);
+	}
+	p_result->collision_count = collision_limit;
+
+	return found_collision || (recovered && p_recovery_as_collision);
 }

--- a/test_project/tests/character_motion_test.gd
+++ b/test_project/tests/character_motion_test.gd
@@ -1,0 +1,66 @@
+extends SceneTree
+
+var failures := 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _make_box(size: Vector3) -> CollisionShape3D:
+	var node := CollisionShape3D.new()
+	var shape := BoxShape3D.new()
+	shape.size = size
+	node.shape = shape
+	return node
+
+
+func _run() -> void:
+	var floor := StaticBody3D.new()
+	floor.position = Vector3(0, -0.5, 0)
+	floor.add_child(_make_box(Vector3(20, 1, 20)))
+	root.add_child(floor)
+
+	var wall := StaticBody3D.new()
+	wall.position = Vector3(0, 3, -3)
+	wall.add_child(_make_box(Vector3(20, 6, 0.2)))
+	root.add_child(wall)
+
+	var character := CharacterBody3D.new()
+	character.position = Vector3(0, 0.9, 0)
+	var collision := CollisionShape3D.new()
+	var capsule := CapsuleShape3D.new()
+	capsule.radius = 0.35
+	capsule.height = 1.8
+	collision.shape = capsule
+	character.add_child(collision)
+	root.add_child(character)
+	await physics_frame
+
+	var minimum_z := character.position.z
+	var invalid_normal := false
+	for frame in 120:
+		character.velocity = Vector3(1.5, -0.5, -9.0)
+		character.move_and_slide()
+		minimum_z = minf(minimum_z, character.position.z)
+		for index in character.get_slide_collision_count():
+			var normal := character.get_slide_collision(index).get_normal()
+			if not normal.is_normalized():
+				failures += 1
+				invalid_normal = true
+				print("RESULT: FAIL - collision %d on frame %d returned an invalid normal: %s" % [index, frame, normal])
+				break
+		if invalid_normal:
+			break
+		await physics_frame
+
+	if not invalid_normal and minimum_z <= -2.57:
+		failures += 1
+		print("RESULT: FAIL - CharacterBody3D crossed the wall under sustained pressure (z=%.4f)" % minimum_z)
+	if not invalid_normal and absf(character.position.y - 0.9) > 0.03:
+		failures += 1
+		print("RESULT: FAIL - CharacterBody3D did not remain grounded (y=%.4f)" % character.position.y)
+
+	if failures == 0:
+		print("RESULT: PASS - CharacterBody3D returns valid normals and remains grounded at a wall")
+	quit(1 if failures > 0 else 0)


### PR DESCRIPTION
## Summary

- recover enabled body shapes from initial overlap before performing motion casts
- respect collision exceptions and derive recovery from actual collider bounds
- reject Box3D initial casts that carry a zero normal
- return normalized motion collisions and add a focused capsule-on-floor-against-wall regression

This fixes the invalid zero normal passed into `CharacterBody3D.move_and_slide()` while keeping SeparationRay and slope-specific behavior outside this focused change.

Closes #21

## Validation

- reproduced the reported zero-normal error on the upstream binary with official Godot 4.7
- focused `character_motion_test.gd` passed with official Godot 4.7
- all 20 branch headless tests passed with Godot 4.6.3
- complete CMake build and `git diff --check`