### PR TITLE
Support SeparationRayShape3D motion queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use this if you have an existing project or want stock nodes and addons to work.
 ## What works
 
 - Rigid, static, and kinematic bodies
-- Shapes: box, sphere, capsule, cylinder, convex polygon, concave polygon (trimesh), heightmap, and world boundary
+- Shapes: box, sphere, capsule, cylinder, convex polygon, concave polygon (trimesh), heightmap, and world boundary; separation rays work in direct and CharacterBody motion queries
 - Areas, including overlap events, gravity/damping overrides, priority ordering, and point gravity
 - Direct space state queries: ray casts, point and shape intersection, shape casts (`cast_motion`), `collide_shape`, and `rest_info`
 - `body_test_motion`, so `CharacterBody3D` and `move_and_slide()` work
@@ -51,11 +51,10 @@ Use this if you have an existing project or want stock nodes and addons to work.
 - Per-pair collision exceptions
 - Joints: pin, hinge, and slider (pin anchors can be moved after creation)
 - Multithreaded solver: the worker count auto-detects physical cores and can be overridden with the `physics/box3d/worker_count` project setting (results are deterministic across worker counts)
-- A test project with a demo hub, a deterministic benchmark, and 19 headless regression tests
+- A test project with a demo hub, a deterministic benchmark, and 20 headless regression tests
 
 ## What's left to do
 
-- Separation ray shapes
 - ConeTwist joints
 - `Generic6DOFJoint3D` (Box3D has no per-axis lock/limit/motor constraint, so there is no faithful mapping; use `PinJoint3D`, `HingeJoint3D`, or `SliderJoint3D` instead)
 - `SoftBody3D`
@@ -155,7 +154,7 @@ cmake --build build-win --parallel
 GODOT_BIN=/path/to/godot scripts/run_headless_tests.sh
 ```
 
-The runner builds the extension, registers it, checks the Box3D backend actually loaded, then runs 19 headless regression tests. It exits nonzero if a test fails or leaks a Box3D RID. `GODOT_BIN` can be omitted when a suitable `godot` is on `PATH`.
+The runner builds the extension, registers it, checks the Box3D backend actually loaded, then runs 20 headless regression tests. It exits nonzero if a test fails or leaks a Box3D RID. `GODOT_BIN` can be omitted when a suitable `godot` is on `PATH`.
 
 ## Contributing
 

--- a/docs/behavior-differences.md
+++ b/docs/behavior-differences.md
@@ -6,6 +6,12 @@ title: Behavior differences
 
 Places where Box3D behaves differently from Godot's built-in physics. These are design differences in the underlying engine, not bugs, and none of them are things a drop-in backend can paper over.
 
+## Separation rays are query-only
+
+`SeparationRayShape3D` participates in direct shape queries and in `body_test_motion`, including `CharacterBody3D` floor snap and `slide_on_slope`. It does not create a Box3D fixture, so attaching one to a `RigidBody3D` or `Area3D` does not add ordinary contacts or monitoring events.
+
+This keeps the zero-width ray from changing body mass or generating regular collision response. Use it for character motion, which is its intended Godot use; use a finite convex shape when a simulated body or area needs contacts.
+
 ## `Area3D` does not detect trimesh or heightmap bodies
 
 In Box3D a concave shape (`ConcavePolygonShape3D`) or `HeightMapShape3D` can never act as a sensor *visitor*, by design, since testing an arbitrary mesh against a sensor is too expensive.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Box3D is worth trying because of where it came from. [Erin Catto](https://x.com/
 ## What works
 
 - Rigid, static, and kinematic bodies
-- Shapes: box, sphere, capsule, cylinder, convex polygon, concave polygon (trimesh), heightmap, and world boundary
+- Shapes: box, sphere, capsule, cylinder, convex polygon, concave polygon (trimesh), heightmap, and world boundary; separation rays work in direct and CharacterBody motion queries
 - Areas, including overlap events, gravity/damping overrides, priority ordering, and point gravity
 - Direct space state queries: ray casts, point and shape intersection, shape casts (`cast_motion`), `collide_shape`, and `rest_info`
 - `body_test_motion`, so `CharacterBody3D` and `move_and_slide()` work
@@ -37,7 +37,6 @@ Box3D is worth trying because of where it came from. [Erin Catto](https://x.com/
 
 ## What's left
 
-- Separation ray shapes
 - ConeTwist joints
 - `Generic6DOFJoint3D` (Box3D has no per-axis lock/limit/motor constraint, so there is no faithful mapping)
 - `SoftBody3D`

--- a/src/misc/box3d_shape_proxy.cpp
+++ b/src/misc/box3d_shape_proxy.cpp
@@ -6,6 +6,7 @@
 #include "../shapes/box3d_capsule_shape_impl_3d.hpp"
 #include "../shapes/box3d_convex_polygon_shape_impl_3d.hpp"
 #include "../shapes/box3d_cylinder_shape_impl_3d.hpp"
+#include "../shapes/box3d_separation_ray_shape_impl_3d.hpp"
 #include "../shapes/box3d_shape_impl_3d.hpp"
 #include "../shapes/box3d_sphere_shape_impl_3d.hpp"
 
@@ -17,6 +18,18 @@ Box3DShapeProxy3D::Box3DShapeProxy3D(const Box3DShapeImpl3D* p_shape, const Tran
 	}
 
 	switch (p_shape->get_type()) {
+		case PhysicsServer3D::SHAPE_SEPARATION_RAY: {
+			const auto* ray = static_cast<const Box3DSeparationRayShapeImpl3D*>(p_shape);
+			points.resize(2);
+			points[0] = godot_to_b3(p_transform.origin);
+			points[1] = godot_to_b3(p_transform.xform(Vector3(0, 0, ray->get_length())));
+			proxy.points = points.ptr();
+			proxy.count = 2;
+			proxy.radius = 0.0f;
+			supported = true;
+			break;
+		}
+
 		case PhysicsServer3D::SHAPE_SPHERE: {
 			const auto* sphere = static_cast<const Box3DSphereShapeImpl3D*>(p_shape);
 			points.resize(1);

--- a/src/misc/box3d_shape_proxy.hpp
+++ b/src/misc/box3d_shape_proxy.hpp
@@ -10,9 +10,10 @@ using namespace godot;
 class Box3DShapeImpl3D;
 
 // Builds a b3ShapeProxy (point cloud + radius, as used by b3World_OverlapShape/CastShape)
-// matching a given Godot Shape3D: sphere -> 1 point + radius; capsule -> 2 points +
-// radius; box/convex hull -> N hull points + 0 radius, all transformed into p_transform's
-// space. Mesh/heightfield/world-boundary shapes have no finite point-cloud representation
+// matching a given Godot Shape3D: separation ray -> 2 points; sphere -> 1 point + radius;
+// capsule -> 2 points + radius; box/convex hull -> N hull points + 0 radius, all
+// transformed into p_transform's space. Mesh/heightfield/world-boundary shapes have no
+// finite point-cloud representation
 // usable with Box3D's GJK-based queries, so they report is_supported() == false; callers
 // should fall back to a different strategy (e.g. AABB overlap) for those shape types.
 class Box3DShapeProxy3D {

--- a/src/objects/box3d_shaped_object_impl_3d.cpp
+++ b/src/objects/box3d_shaped_object_impl_3d.cpp
@@ -53,6 +53,11 @@ b3ShapeId create_box3d_shape(
 	const Transform3D& local = p_instance.get_transform();
 
 	switch (type) {
+		case PhysicsServer3D::SHAPE_SEPARATION_RAY:
+			// Separation rays only participate in motion queries. Giving a zero-width
+			// segment a live fixture would make it affect mass and regular contacts.
+			return b3_nullShapeId;
+
 		case PhysicsServer3D::SHAPE_SPHERE: {
 			auto* sphere_shape = static_cast<Box3DSphereShapeImpl3D*>(shape);
 			b3Sphere sphere;

--- a/src/servers/box3d_physics_server_3d.cpp
+++ b/src/servers/box3d_physics_server_3d.cpp
@@ -16,6 +16,7 @@
 #include "../shapes/box3d_convex_polygon_shape_impl_3d.hpp"
 #include "../shapes/box3d_cylinder_shape_impl_3d.hpp"
 #include "../shapes/box3d_heightmap_shape_impl_3d.hpp"
+#include "../shapes/box3d_separation_ray_shape_impl_3d.hpp"
 #include "../shapes/box3d_shape_impl_3d.hpp"
 #include "../shapes/box3d_sphere_shape_impl_3d.hpp"
 #include "../shapes/box3d_world_boundary_shape_impl_3d.hpp"
@@ -87,7 +88,10 @@ RID Box3DPhysicsServer3D::_world_boundary_shape_create() {
 }
 
 RID Box3DPhysicsServer3D::_separation_ray_shape_create() {
-	ERR_FAIL_V_MSG(RID(), "Box3D: SeparationRayShape3D is not supported in this version of the Box3D extension.");
+	auto* shape = memnew(Box3DSeparationRayShapeImpl3D);
+	const RID rid = shape_owner.make_rid(shape);
+	shape->set_rid(rid);
+	return rid;
 }
 
 RID Box3DPhysicsServer3D::_sphere_shape_create() {
@@ -908,7 +912,15 @@ bool Box3DPhysicsServer3D::_body_test_motion(
 	Box3DSpace3D* space = body->get_space();
 	ERR_FAIL_NULL_V(space, false);
 
-	return space->get_direct_state()->test_body_motion(*body, p_from, p_motion, p_margin, p_max_collisions, p_recovery_as_collision, p_result);
+	return space->get_direct_state()->test_body_motion(
+			*body,
+			p_from,
+			p_motion,
+			p_margin,
+			p_max_collisions,
+			p_collide_separation_ray,
+			p_recovery_as_collision,
+			p_result);
 }
 
 PhysicsDirectBodyState3D* Box3DPhysicsServer3D::_body_get_direct_state(const RID& p_body) {

--- a/src/shapes/box3d_separation_ray_shape_impl_3d.cpp
+++ b/src/shapes/box3d_separation_ray_shape_impl_3d.cpp
@@ -1,0 +1,25 @@
+#include "box3d_separation_ray_shape_impl_3d.hpp"
+
+#include <godot_cpp/variant/dictionary.hpp>
+
+Variant Box3DSeparationRayShapeImpl3D::get_data() const {
+	Dictionary data;
+	data["length"] = length;
+	data["slide_on_slope"] = slide_on_slope;
+	return data;
+}
+
+void Box3DSeparationRayShapeImpl3D::set_data(const Variant& p_data) {
+	ERR_FAIL_COND(p_data.get_type() != Variant::DICTIONARY);
+	const Dictionary data = p_data;
+	const Variant maybe_length = data.get("length", Variant());
+	const Variant maybe_slide_on_slope = data.get("slide_on_slope", Variant());
+	ERR_FAIL_COND(maybe_length.get_type() != Variant::FLOAT && maybe_length.get_type() != Variant::INT);
+	ERR_FAIL_COND(maybe_slide_on_slope.get_type() != Variant::BOOL);
+	length = maybe_length;
+	slide_on_slope = maybe_slide_on_slope;
+}
+
+AABB Box3DSeparationRayShapeImpl3D::get_aabb() const {
+	return AABB(Vector3(), Vector3(0.1, 0.1, length));
+}

--- a/src/shapes/box3d_separation_ray_shape_impl_3d.hpp
+++ b/src/shapes/box3d_separation_ray_shape_impl_3d.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "box3d_shape_impl_3d.hpp"
+
+class Box3DSeparationRayShapeImpl3D final : public Box3DShapeImpl3D {
+public:
+	ShapeType get_type() const override { return PhysicsServer3D::SHAPE_SEPARATION_RAY; }
+
+	Variant get_data() const override;
+
+	void set_data(const Variant& p_data) override;
+
+	AABB get_aabb() const override;
+
+	real_t get_length() const { return length; }
+
+	bool get_slide_on_slope() const { return slide_on_slope; }
+
+private:
+	real_t length = 1.0;
+	bool slide_on_slope = false;
+};

--- a/src/spaces/box3d_physics_direct_space_state_3d.cpp
+++ b/src/spaces/box3d_physics_direct_space_state_3d.cpp
@@ -6,6 +6,7 @@
 #include "../objects/box3d_body_impl_3d.hpp"
 #include "../objects/box3d_shaped_object_impl_3d.hpp"
 #include "../servers/box3d_physics_server_3d.hpp"
+#include "../shapes/box3d_separation_ray_shape_impl_3d.hpp"
 #include "../shapes/box3d_shape_impl_3d.hpp"
 #include "box3d_query_filter_3d.hpp"
 #include "box3d_space_3d.hpp"
@@ -399,6 +400,7 @@ bool Box3DPhysicsDirectSpaceState3D::test_body_motion(
 		const Vector3& p_motion,
 		double p_margin,
 		int32_t p_max_collisions,
+		bool p_collide_separation_ray,
 		bool p_recovery_as_collision,
 		PhysicsServer3DExtensionMotionResult* p_result) const {
 	ERR_FAIL_NULL_V(space, false);
@@ -416,28 +418,68 @@ bool Box3DPhysicsDirectSpaceState3D::test_body_motion(
 		return false;
 	}
 
-	Box3DShapeImpl3D* first_shape = p_body.get_shape(0);
-	if (first_shape == nullptr) {
-		p_result->travel = p_motion;
-		p_result->remainder = Vector3();
-		return false;
-	}
-
 	Box3DQueryFilter3D filter;
 	filter.set_collision_mask(p_body.get_collision_mask());
 	filter.exclude.insert(p_body.get_rid());
 
-	const Box3DShapeProxy3D shape_proxy(first_shape, p_transform * p_body.get_shape_transform(0));
-	if (!shape_proxy.is_supported()) {
-		p_result->travel = p_motion;
-		p_result->remainder = Vector3();
-		return false;
-	}
-
 	RayContext context;
 	context.filter = &filter;
+	int32_t local_shape = -1;
+	Vector3 normal_override;
+	bool cast_regular_shape = true;
 
-	b3World_CastShape(space->get_world_id(), b3Vec3_zero, &shape_proxy.get_proxy(), godot_to_b3(p_motion), filter.filter, cast_result_fcn, &context);
+	for (int32_t i = 0; i < p_body.get_shape_count(); i++) {
+		if (p_body.is_shape_disabled(i)) {
+			continue;
+		}
+		Box3DShapeImpl3D* shape = p_body.get_shape(i);
+		if (shape == nullptr) {
+			continue;
+		}
+
+		const bool is_separation_ray = shape->get_type() == PhysicsServer3D::SHAPE_SEPARATION_RAY;
+		if (is_separation_ray) {
+			const auto* ray = static_cast<const Box3DSeparationRayShapeImpl3D*>(shape);
+			if (!p_collide_separation_ray && !ray->get_slide_on_slope()) {
+				continue;
+			}
+		} else if (!cast_regular_shape) {
+			// Preserve the existing single regular-shape behavior while also considering
+			// every separation ray attached to a typical CharacterBody3D.
+			continue;
+		}
+
+		const Transform3D shape_transform = p_transform * p_body.get_shape_transform(i);
+		const Box3DShapeProxy3D shape_proxy(shape, shape_transform);
+		if (!shape_proxy.is_supported()) {
+			continue;
+		}
+
+		RayContext candidate;
+		candidate.filter = &filter;
+		b3World_CastShape(
+				space->get_world_id(),
+				b3Vec3_zero,
+				&shape_proxy.get_proxy(),
+				godot_to_b3(p_motion),
+				filter.filter,
+				cast_result_fcn,
+				&candidate);
+		if (candidate.has_hit && (!context.has_hit || candidate.fraction < context.fraction)) {
+			context = candidate;
+			local_shape = i;
+			normal_override = Vector3();
+			if (is_separation_ray) {
+				const auto* ray = static_cast<const Box3DSeparationRayShapeImpl3D*>(shape);
+				if (!ray->get_slide_on_slope()) {
+					normal_override = -shape_transform.basis.get_column(2).normalized();
+				}
+			}
+		}
+		if (!is_separation_ray) {
+			cast_regular_shape = false;
+		}
+	}
 
 	if (!context.has_hit) {
 		p_result->travel = p_motion;
@@ -455,10 +497,11 @@ bool Box3DPhysicsDirectSpaceState3D::test_body_motion(
 	if (other != nullptr && p_max_collisions > 0) {
 		PhysicsServer3DExtensionMotionCollision& collision = p_result->collisions[0];
 		collision.position = b3_to_godot(context.point);
-		collision.normal = b3_to_godot(context.normal);
+		collision.normal = normal_override.is_zero_approx() ? b3_to_godot(context.normal) : normal_override;
 		collision.collider = other->get_rid();
 		collision.collider_id = other->get_instance_id();
 		collision.collider_shape = 0;
+		collision.local_shape = local_shape;
 		collision.depth = 0.0f;
 		p_result->collision_count = 1;
 	}

--- a/src/spaces/box3d_physics_direct_space_state_3d.hpp
+++ b/src/spaces/box3d_physics_direct_space_state_3d.hpp
@@ -94,6 +94,7 @@ public:
 			const Vector3& p_motion,
 			double p_margin,
 			int32_t p_max_collisions,
+			bool p_collide_separation_ray,
 			bool p_recovery_as_collision,
 			PhysicsServer3DExtensionMotionResult* p_result) const;
 

--- a/test_project/tests/separation_ray_test.gd
+++ b/test_project/tests/separation_ray_test.gd
@@ -1,0 +1,122 @@
+extends SceneTree
+
+var failures: int = 0
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var floor_body := StaticBody3D.new()
+	var floor_collision := CollisionShape3D.new()
+	var floor_shape := BoxShape3D.new()
+	floor_shape.size = Vector3(20.0, 1.0, 20.0)
+	floor_collision.shape = floor_shape
+	floor_body.add_child(floor_collision)
+	floor_body.position = Vector3(0.0, -0.5, 0.0)
+	root.add_child(floor_body)
+
+	var body := CharacterBody3D.new()
+	body.position = Vector3(0.0, 1.6, 0.0)
+	var body_collision := CollisionShape3D.new()
+	var body_shape := CapsuleShape3D.new()
+	body_shape.radius = 0.25
+	body_shape.height = 0.5
+	body_collision.shape = body_shape
+	body.add_child(body_collision)
+	var ray_collision := CollisionShape3D.new()
+	ray_collision.rotation.x = PI / 2.0
+	var ray_shape := SeparationRayShape3D.new()
+	ray_shape.length = 1.5
+	ray_collision.shape = ray_shape
+	body.add_child(ray_collision)
+	root.add_child(body)
+
+	await physics_frame
+	await physics_frame
+
+	var disabled_result := PhysicsTestMotionResult3D.new()
+	var disabled_hit := PhysicsServer3D.body_test_motion(
+			body.get_rid(), _motion_parameters(body, false), disabled_result)
+	_check(not disabled_hit, "regular motion ignores a non-sliding separation ray")
+	_check(disabled_result.get_travel().is_equal_approx(Vector3(0.0, -0.25, 0.0)),
+			"ignored separation ray leaves the requested travel unchanged")
+
+	var enabled_result := PhysicsTestMotionResult3D.new()
+	var enabled_hit := PhysicsServer3D.body_test_motion(
+			body.get_rid(), _motion_parameters(body, true), enabled_result)
+	_check(enabled_hit, "collide_separation_ray detects the floor")
+	_check(enabled_result.get_collision_count() == 1, "separation ray reports one collision")
+	if enabled_result.get_collision_count() == 1:
+		_check(enabled_result.get_collision_normal().is_equal_approx(Vector3.UP),
+				"non-sliding separation ray reports the opposite ray direction")
+		_check(enabled_result.get_collision_local_shape() == 1,
+				"separation ray reports its local shape index")
+	_check(absf(enabled_result.get_collision_unsafe_fraction() - 0.4) < 0.03,
+			"separation ray stops when its endpoint reaches the floor within solver slop")
+
+	var slope_body := StaticBody3D.new()
+	var slope_collision := CollisionShape3D.new()
+	var slope_shape := BoxShape3D.new()
+	slope_shape.size = Vector3(4.0, 1.0, 4.0)
+	slope_collision.shape = slope_shape
+	slope_body.add_child(slope_collision)
+	slope_body.position = Vector3(5.0, 0.0, 0.0)
+	slope_body.rotation.z = PI / 6.0
+	root.add_child(slope_body)
+
+	var slope_character := CharacterBody3D.new()
+	slope_character.position = Vector3(5.0, 0.5 / cos(PI / 6.0) + 1.6, 0.0)
+	var slope_body_collision := CollisionShape3D.new()
+	var slope_body_shape := CapsuleShape3D.new()
+	slope_body_shape.radius = 0.25
+	slope_body_shape.height = 0.5
+	slope_body_collision.shape = slope_body_shape
+	slope_character.add_child(slope_body_collision)
+	var slope_ray_collision := CollisionShape3D.new()
+	slope_ray_collision.rotation.x = PI / 2.0
+	var slope_ray_shape := SeparationRayShape3D.new()
+	slope_ray_shape.length = 1.5
+	slope_ray_shape.slide_on_slope = true
+	slope_ray_collision.shape = slope_ray_shape
+	slope_character.add_child(slope_ray_collision)
+	root.add_child(slope_character)
+
+	await physics_frame
+	var slope_result := PhysicsTestMotionResult3D.new()
+	var slope_hit := PhysicsServer3D.body_test_motion(
+			slope_character.get_rid(), _motion_parameters(slope_character, false), slope_result)
+	_check(slope_hit, "slide_on_slope rays participate in regular motion")
+	_check(slope_result.get_collision_count() == 1, "slide_on_slope ray reports one collision")
+	if slope_result.get_collision_count() == 1:
+		var expected_normal := slope_body.transform.basis * Vector3.UP
+		_check(slope_result.get_collision_normal().dot(expected_normal) > 0.99,
+				"slide_on_slope reports the surface normal")
+
+	var data: Dictionary = PhysicsServer3D.shape_get_data(ray_shape.get_rid())
+	_check(is_equal_approx(data.get("length", 0.0), 1.5), "shape data preserves ray length")
+	_check(data.get("slide_on_slope", true) == false, "shape data preserves slide_on_slope")
+
+	if failures == 0:
+		print("RESULT: PASS - separation rays support CharacterBody motion queries")
+	else:
+		print("RESULT: FAIL - ", failures, " separation ray assertion(s) failed")
+	quit(1 if failures > 0 else 0)
+
+
+func _motion_parameters(body: CharacterBody3D, collide_separation_ray: bool) -> PhysicsTestMotionParameters3D:
+	var parameters := PhysicsTestMotionParameters3D.new()
+	parameters.from = body.global_transform
+	parameters.motion = Vector3(0.0, -0.25, 0.0)
+	parameters.margin = 0.001
+	parameters.collide_separation_ray = collide_separation_ray
+	return parameters
+
+
+func _check(condition: bool, message: String) -> void:
+	if condition:
+		print("PASS: ", message)
+	else:
+		failures += 1
+		push_error("FAIL: " + message)


### PR DESCRIPTION
## Summary

- add the Godot-side SeparationRayShape3D data and AABB contract without creating a zero-width Box3D fixture
- include separation rays alongside the existing regular body shape in body motion casts
- honor collide_separation_ray and slide_on_slope, including the expected collision normal
- document that rigid-body contacts and Area3D monitoring remain out of scope for this query-only shape

## Regression coverage

The focused test uses the typical CharacterBody3D setup (capsule plus ray) and checks ignored regular motion, snap-enabled endpoint contact, local shape index, shape data, and an inclined slide_on_slope surface.

## Validation

- Godot 4.7 stable: all 20 headless tests passed
- Godot 4.6.3 stable compatibility replay: all 20 headless tests passed
- git diff --check

This is intentionally a draft while the existing six ready-for-review pull requests remain open.